### PR TITLE
feat(signer)!: add proxy keys

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,4 @@ rand = "0.8.5"
 dotenvy = "0.15.7"
 indexmap = "2.2.6"
 lazy_static = "1.5.0"
+bimap = { version = "0.6.3", features = ["serde"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -33,3 +33,5 @@ thiserror.workspace = true
 eyre.workspace = true
 url.workspace = true
 rand.workspace = true
+bimap.workspace = true
+derive_more = "0.99.18"

--- a/crates/common/src/commit/client.rs
+++ b/crates/common/src/commit/client.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use alloy::rpc::types::beacon::{BlsPublicKey, BlsSignature};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::{header::{HeaderMap, HeaderValue, AUTHORIZATION}, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    constants::{GET_PUBKEYS_PATH, REQUEST_SIGNATURE_PATH},
+    constants::{GENERATE_PROXY_KEY_PATH, GET_PUBKEYS_PATH, REQUEST_SIGNATURE_PATH},
     error::SignerClientError,
-    request::SignRequest,
+    request::{GenerateProxyRequest, SignRequest, SignedProxyDelegation},
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -82,5 +82,28 @@ impl SignerClient {
         let signature: BlsSignature = serde_json::from_slice(&response_bytes)?;
 
         Ok(signature)
+    }
+
+    pub async fn generate_proxy_key(
+        &self,
+        pubkey: BlsPublicKey,
+    ) -> Result<SignedProxyDelegation, SignerClientError> {
+        let url = format!("{}{}", self.url, GENERATE_PROXY_KEY_PATH);
+        let request = GenerateProxyRequest::new(pubkey);
+        let res = self.client.post(&url).json(&request).send().await?;
+
+        let status = res.status();
+        let response_bytes = res.bytes().await?;
+
+        if !status.is_success() {
+            return Err(SignerClientError::FailedRequest {
+                status: status.as_u16(),
+                error_msg: String::from_utf8_lossy(&response_bytes).into_owned(),
+            });
+        }
+
+        let signed_proxy_delegation = serde_json::from_slice(&response_bytes)?;
+
+        Ok(signed_proxy_delegation)
     }
 }

--- a/crates/common/src/commit/constants.rs
+++ b/crates/common/src/commit/constants.rs
@@ -1,2 +1,3 @@
 pub const GET_PUBKEYS_PATH: &str = "/signer/v1/get_pubkeys";
 pub const REQUEST_SIGNATURE_PATH: &str = "/signer/v1/request_signature";
+pub const GENERATE_PROXY_KEY_PATH: &str = "/signer/v1/generate_proxy_key";

--- a/crates/common/src/commit/error.rs
+++ b/crates/common/src/commit/error.rs
@@ -6,7 +6,7 @@ pub enum SignerClientError {
     #[error("invalid header value: {0}")]
     InvalidHeader(#[from] reqwest::header::InvalidHeaderValue),
 
-    #[error("failed request: status {status} msg {error_msg}")]
+    #[error("failed request: status {status}; message: \"{error_msg}\"")]
     FailedRequest { status: u16, error_msg: String },
 
     #[error("serde decode error: {0}")]

--- a/crates/common/src/commit/request.rs
+++ b/crates/common/src/commit/request.rs
@@ -34,7 +34,6 @@ impl SignedProxyDelegation {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignRequest {
-    pub id: String,
     pub pubkey: BlsPublicKey,
     pub is_proxy: bool,
     pub object_root: [u8; 32],
@@ -42,16 +41,15 @@ pub struct SignRequest {
 
 impl SignRequest {
     pub fn new(
-        id: impl Into<String>,
         pubkey: BlsPublicKey,
         is_proxy: bool,
         object_root: [u8; 32],
     ) -> SignRequest {
-        Self { id: id.into(), pubkey, is_proxy, object_root }
+        Self { pubkey, is_proxy, object_root }
     }
 
-    pub fn builder(id: impl Into<String>, pubkey: BlsPublicKey) -> Self {
-        Self::new(id, pubkey, false, [0; 32])
+    pub fn builder(pubkey: BlsPublicKey) -> Self {
+        Self::new(pubkey, false, [0; 32])
     }
 
     pub fn is_proxy(self) -> Self {
@@ -63,6 +61,17 @@ impl SignRequest {
     }
 
     pub fn with_msg(self, msg: &impl TreeHash) -> Self {
-        Self { object_root: msg.tree_hash_root().0, ..self }
+        self.with_root(msg.tree_hash_root().0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateProxyRequest {
+    pub pubkey: BlsPublicKey,
+}
+
+impl GenerateProxyRequest {
+    pub fn new(pubkey: BlsPublicKey) -> Self {
+        GenerateProxyRequest { pubkey }
     }
 }

--- a/crates/common/src/signature.rs
+++ b/crates/common/src/signature.rs
@@ -90,9 +90,7 @@ pub fn sign_builder_message(
     secret_key: &SecretKey,
     msg: &impl TreeHash,
 ) -> BlsSignature {
-    let domain = chain.builder_domain();
-    let signing_root = compute_signing_root(msg.tree_hash_root().0, domain);
-    sign_message(secret_key, &signing_root)
+    sign_builder_root(chain, secret_key, msg.tree_hash_root().0)
 }
 
 pub fn sign_builder_root(

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,3 +1,5 @@
+use derive_more::{Deref, From, Into, Display};
+
 use serde::{Deserialize, Serialize};
 
 use crate::constants::{
@@ -43,3 +45,13 @@ impl Chain {
         }
     }
 }
+
+#[derive(Clone, Debug, Display, PartialEq, Eq, Hash, Deref, From, Into, Serialize, Deserialize)]
+#[into(owned, ref, ref_mut)]
+#[serde(transparent)]
+pub struct ModuleId(pub String);
+
+#[derive(Clone, Debug, Display, PartialEq, Eq, Hash, Deref, From, Into, Serialize, Deserialize)]
+#[into(owned, ref, ref_mut)]
+#[serde(transparent)]
+pub struct Jwt(pub String);

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -36,3 +36,5 @@ thiserror.workspace = true
 eyre.workspace = true
 rand.workspace = true
 uuid.workspace = true
+bimap.workspace = true
+lazy_static.workspace = true

--- a/crates/signer/src/error.rs
+++ b/crates/signer/src/error.rs
@@ -3,6 +3,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use cb_common::types::ModuleId;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,7 +12,7 @@ pub enum SignerModuleError {
     Unauthorized,
 
     #[error("unknown module id: {0}")]
-    UnknownModuleId(String),
+    UnknownModuleId(ModuleId),
 
     #[error("unknown consensus signer: {0}")]
     UnknownConsensusSigner(BlsPublicKey),

--- a/crates/signer/src/manager.rs
+++ b/crates/signer/src/manager.rs
@@ -4,7 +4,7 @@ use alloy::rpc::types::beacon::{BlsPublicKey, BlsSignature};
 use cb_common::{
     commit::request::{ProxyDelegation, SignedProxyDelegation},
     signer::Signer,
-    types::Chain,
+    types::{Chain, ModuleId},
 };
 use tree_hash::TreeHash;
 
@@ -18,6 +18,7 @@ use crate::error::SignerModuleError;
 // for slashing the faulty message + proxy delegation can be used
 // Signed using builder domain
 
+#[derive(Clone)]
 pub struct ProxySigner {
     signer: Signer,
     delegation: SignedProxyDelegation,
@@ -27,11 +28,20 @@ pub struct SigningManager {
     chain: Chain,
     consensus_signers: HashMap<BlsPublicKey, Signer>,
     proxy_signers: HashMap<BlsPublicKey, ProxySigner>,
+    /// Map of module ids to their associated proxy pubkeys.
+    /// Used to retrieve the corresponding proxy signer from the signing
+    /// manager.
+    proxy_pubkeys: HashMap<ModuleId, Vec<BlsPublicKey>>,
 }
 
 impl SigningManager {
     pub fn new(chain: Chain) -> Self {
-        Self { chain, consensus_signers: HashMap::new(), proxy_signers: HashMap::new() }
+        Self {
+            chain,
+            consensus_signers: HashMap::new(),
+            proxy_signers: HashMap::new(),
+            proxy_pubkeys: HashMap::new(),
+        }
     }
 
     pub fn add_consensus_signer(&mut self, signer: Signer) {
@@ -44,16 +54,20 @@ impl SigningManager {
 
     pub async fn create_proxy(
         &mut self,
+        module_id: ModuleId,
         delegator: BlsPublicKey,
     ) -> Result<SignedProxyDelegation, SignerModuleError> {
         let signer = Signer::new_random();
+        let proxy_pubkey = signer.pubkey();
 
-        let message = ProxyDelegation { delegator, proxy: signer.pubkey() };
+        let message = ProxyDelegation { delegator, proxy: proxy_pubkey };
         let signature = self.sign_consensus(&delegator, &message.tree_hash_root().0).await?;
         let signed_delegation: SignedProxyDelegation = SignedProxyDelegation { signature, message };
         let proxy_signer = ProxySigner { signer, delegation: signed_delegation };
 
+        // Add the new proxy key to the manager's internal state
         self.add_proxy_signer(proxy_signer);
+        self.proxy_pubkeys.entry(module_id).or_default().push(proxy_pubkey);
 
         Ok(signed_delegation)
     }
@@ -89,8 +103,8 @@ impl SigningManager {
         self.consensus_signers.keys().cloned().collect()
     }
 
-    pub fn proxy_pubkeys(&self) -> Vec<BlsPublicKey> {
-        self.proxy_signers.keys().cloned().collect()
+    pub fn proxy_pubkeys(&self) -> &HashMap<ModuleId, Vec<BlsPublicKey>> {
+        &self.proxy_pubkeys
     }
 
     pub fn delegations(&self) -> Vec<SignedProxyDelegation> {
@@ -114,5 +128,93 @@ impl SigningManager {
             .get(proxy_pubkey)
             .ok_or(SignerModuleError::UnknownProxySigner(*proxy_pubkey))?;
         Ok(signer.delegation)
+    }
+}
+
+// TODO(David): Add more tests.
+#[cfg(test)]
+mod tests {
+    use blst::BLST_ERROR;
+    use cb_common::signature::verify_signed_builder_message;
+    use lazy_static::lazy_static;
+    use tree_hash::Hash256;
+
+    use super::*;
+
+    lazy_static! {
+        static ref CHAIN: Chain = Chain::Holesky;
+        static ref MODULE_ID: ModuleId = ModuleId("SAMPLE_MODULE".to_string());
+    }
+
+    fn init_signing_manager() -> (SigningManager, BlsPublicKey) {
+        let mut signing_manager = SigningManager::new(*CHAIN);
+
+        let consensus_signer = Signer::new_random();
+        let consensus_pk = consensus_signer.pubkey();
+
+        signing_manager.add_consensus_signer(consensus_signer.clone());
+
+        (signing_manager, consensus_pk)
+    }
+
+    #[tokio::test]
+    async fn test_proxy_key_is_valid_proxy_for_consensus_key() {
+        let (mut signing_manager, consensus_pk) = init_signing_manager();
+
+        let signed_delegation = signing_manager.create_proxy(MODULE_ID.clone(), consensus_pk.clone()).await.unwrap();
+
+        let validation_result = signed_delegation.validate(*CHAIN);
+
+        assert!(
+            validation_result.is_ok(),
+            "Proxy delegation signature must be valid for consensus key."
+        );
+
+        assert!(
+            signing_manager.has_proxy(&signed_delegation.message.proxy),
+            "Newly generated proxy key must be present in the signing manager's registry."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tampered_proxy_key_is_invalid() {
+        let (mut signing_manager, consensus_pk) = init_signing_manager();
+
+        let mut signed_delegation = signing_manager.create_proxy(MODULE_ID.clone(), consensus_pk.clone()).await.unwrap();
+
+        let m = &mut signed_delegation.signature.0[0];
+        (*m, _) = m.overflowing_add(1);
+
+        let validation_result = signed_delegation.validate(*CHAIN);
+
+        assert!(
+            matches!(validation_result, Err(BLST_ERROR::BLST_POINT_NOT_ON_CURVE)),
+            "Tampered proxy key must be invalid."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_key_signs_message() {
+        let (mut signing_manager, consensus_pk) = init_signing_manager();
+
+        let signed_delegation = signing_manager.create_proxy(MODULE_ID.clone(), consensus_pk.clone()).await.unwrap();
+        let proxy_pk = signed_delegation.message.proxy;
+
+        let data_root = Hash256::random();
+        let data_root_bytes = data_root.as_fixed_bytes();
+
+        let sig = signing_manager.sign_proxy(&proxy_pk, data_root_bytes).await.unwrap();
+
+        let validation_result = verify_signed_builder_message(
+            *CHAIN,
+            &signed_delegation.message.proxy,
+            &data_root_bytes,
+            &sig,
+        );
+
+        assert!(
+            validation_result.is_ok(),
+            "Proxy keypair must produce valid signatures of messages."
+        )
     }
 }

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -1,23 +1,26 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use axum::{
-    extract::State,
+    extract::{Request, State},
     http::StatusCode,
-    response::IntoResponse,
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
     routing::{get, post},
-    Json,
+    Extension, Json,
 };
 use axum_extra::TypedHeader;
+use bimap::BiHashMap;
 use cb_common::{
     commit::{
         client::GetPubkeysResponse,
-        constants::{GET_PUBKEYS_PATH, REQUEST_SIGNATURE_PATH},
-        request::SignRequest,
+        constants::{GENERATE_PROXY_KEY_PATH, GET_PUBKEYS_PATH, REQUEST_SIGNATURE_PATH},
+        request::{GenerateProxyRequest, SignRequest},
     },
     config::StartSignerConfig,
+    types::{Jwt, ModuleId},
 };
 use headers::{authorization::Bearer, Authorization};
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::RwLock};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -29,9 +32,11 @@ pub struct SigningService;
 #[derive(Clone)]
 struct SigningState {
     /// Mananger handling different signing methods
-    manager: Arc<SigningManager>,
-    /// Map of module ids to JWTs. This also acts as registry of all modules running
-    jwts: HashMap<String, String>,
+    manager: Arc<RwLock<SigningManager>>,
+    /// Map of JWTs to module ids. This also acts as registry of all modules running
+    // TODO(David): `Arc` is perhaps not the optimal type here...
+    //  We need readonly async after initialization. Look into that.
+    jwts: Arc<BiHashMap<ModuleId, Jwt>>,
 }
 
 impl SigningService {
@@ -40,7 +45,7 @@ impl SigningService {
             warn!("Signing service was started but no module is registered. Exiting");
             return;
         } else {
-            info!(modules =? config.jwts.keys(), port =? config.server_port, "Starting signing service");
+            info!(modules =? config.jwts.left_values(), port =? config.server_port, "Starting signing service");
         }
 
         let mut manager = SigningManager::new(config.chain);
@@ -50,12 +55,14 @@ impl SigningService {
             manager.add_consensus_signer(signer);
         }
 
-        let state = SigningState { manager: manager.into(), jwts: config.jwts };
+        let state = SigningState { manager: RwLock::new(manager).into(), jwts: config.jwts.into() };
 
         let app = axum::Router::new()
             .route(REQUEST_SIGNATURE_PATH, post(handle_request_signature))
             .route(GET_PUBKEYS_PATH, get(handle_get_pubkeys))
-            .with_state(state);
+            .route(GENERATE_PROXY_KEY_PATH, post(handle_generate_proxy))
+            .with_state(state.clone())
+            .route_layer(middleware::from_fn_with_state(state.clone(), jwt_auth));
 
         let address = SocketAddr::from(([0, 0, 0, 0], config.server_port));
         let listener = TcpListener::bind(address).await.expect("failed tcp binding");
@@ -66,16 +73,40 @@ impl SigningService {
     }
 }
 
+/// Authentication middleware layer
+async fn jwt_auth(
+    State(state): State<SigningState>,
+    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, SignerModuleError> {
+    let jwt: Jwt = auth.token().to_string().into();
+
+    let maybe_module_id = state.jwts.get_by_right(&jwt);
+
+    let Some(module_id) = maybe_module_id else {
+        warn!("Unauthorized request. Was the module started correctly?");
+        return Err(SignerModuleError::Unauthorized);
+    };
+
+    req.extensions_mut().insert(module_id.clone());
+
+    Ok(next.run(req).await)
+}
+
 /// Implements get_pubkeys from the Signer API
 async fn handle_get_pubkeys(
+    Extension(module_id): Extension<ModuleId>,
     State(state): State<SigningState>,
 ) -> Result<impl IntoResponse, SignerModuleError> {
     let req_id = Uuid::new_v4();
 
     debug!(event = "get_pubkeys", ?req_id, "New request");
 
-    let consensus = state.manager.consensus_pubkeys();
-    let proxy = state.manager.proxy_pubkeys();
+    let signing_manager = state.manager.read().await;
+
+    let consensus = signing_manager.consensus_pubkeys();
+    let proxy = signing_manager.proxy_pubkeys().get(&module_id).cloned().unwrap_or_default();
 
     let res = GetPubkeysResponse { consensus, proxy };
 
@@ -84,29 +115,37 @@ async fn handle_get_pubkeys(
 
 /// Implements request_signature from the Signer API
 async fn handle_request_signature(
-    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+    Extension(module_id): Extension<ModuleId>,
     State(state): State<SigningState>,
     Json(request): Json<SignRequest>,
 ) -> Result<impl IntoResponse, SignerModuleError> {
     let req_id = Uuid::new_v4();
 
-    if let Some(jwt) = state.jwts.get(&request.id) {
-        if !auth.token().contains(jwt) {
-            warn!(module_id=?request.id, ?req_id, "Unauthorized request. Was the module started correctly?");
-            return Err(SignerModuleError::Unauthorized);
-        }
-    } else {
-        warn!(module_id=?request.id, ?req_id, "Unknown module id. Was the module started correctly?");
-        return Err(SignerModuleError::UnknownModuleId(request.id));
-    }
+    debug!(event = "request_signature", ?module_id, ?req_id, "New request");
 
-    debug!(event = "request_signature", module_id=?request.id, ?req_id, "New request");
+    let signing_manager = state.manager.read().await;
 
     let sig = if request.is_proxy {
-        state.manager.sign_proxy(&request.pubkey, &request.object_root).await
+        signing_manager.sign_proxy(&request.pubkey, &request.object_root).await
     } else {
-        state.manager.sign_consensus(&request.pubkey, &request.object_root).await
+        signing_manager.sign_consensus(&request.pubkey, &request.object_root).await
     }?;
 
     Ok((StatusCode::OK, Json(sig)).into_response())
+}
+
+async fn handle_generate_proxy(
+    Extension(module_id): Extension<ModuleId>,
+    State(state): State<SigningState>,
+    Json(request): Json<GenerateProxyRequest>,
+) -> Result<impl IntoResponse, SignerModuleError> {
+    let req_id = Uuid::new_v4();
+
+    debug!(event = "generate_proxy", module_id=?module_id, ?req_id, "New request");
+
+    let mut signing_manager = state.manager.write().await;
+
+    let proxy_delegation = signing_manager.create_proxy(module_id, request.pubkey).await?;
+
+    Ok((StatusCode::OK, Json(proxy_delegation)).into_response())
 }


### PR DESCRIPTION
# Quick summary:
- implement a `generate_proxy_keys` endpoint to the Signer API. Modify the signer client accordingly.

- add a `.dockerignore` file

- remove the need for modules to provide their id in requests. A module's JWT is now solely sufficient to identify the module.
  * `SigningService` now contains jwt <-> module_id in a bidirectional hashmap

- add authentication middleware to the signer service instead of manual auth in the handlers

- introduce `ModuleId` and `Jwt` wrapper types around strings to improve semantics (useful after a couple of mishaps with key <-> value directions across the different maps)
  * see `common::types`

- add example proxy key generation request in `da_commit` module

- misc misc changes

- little reformatting

---
# TODOs

- [ ] Update the docs with the new Signer API changes
- [ ] Refine small consideration around my inline `TODO`s
---

closes #19 