### PR TITLE
fix top level error wrap

### DIFF
--- a/bin/commit_boost.rs
+++ b/bin/commit_boost.rs
@@ -11,9 +11,5 @@ async fn main() -> eyre::Result<()> {
 
     let args = cb_cli::Args::parse();
 
-    if let Err(err) = args.run().await {
-        eprintln!("Error: {err}");
-        std::process::exit(1)
-    };
-    Ok(())
+    args.run().await
 }

--- a/bin/default_pbs.rs
+++ b/bin/default_pbs.rs
@@ -18,6 +18,5 @@ async fn main() -> Result<()> {
     let state = PbsState::<()>::new(pbs_config);
 
     PbsService::init_metrics()?;
-    PbsService::run::<(), DefaultBuilderApi>(state).await;
-    Ok(())
+    PbsService::run::<(), DefaultBuilderApi>(state).await
 }


### PR DESCRIPTION
Error in config parsing are now bubbled up to the user. 

**Before**
```bash
Initializing Commit-Boost with config file: config.example.toml
Error: could not deserialize toml from string
```

**Now**
```bash
Initializing Commit-Boost with config file: config.example.toml
Error:
   0: could not deserialize toml from string
   1: TOML parse error at line 16, column 7
   1:    |
   1: 16 | url = "http://invalid-key@abc.xyz"
   1:    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   1: odd number of digits
   1:

Location:
   crates/common/src/config/utils.rs:22
```