### PR TITLE
Fix missing error format for load_env_var

### DIFF
--- a/crates/common/src/config/utils.rs
+++ b/crates/common/src/config/utils.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use super::constants::JWTS_ENV;
 
 pub fn load_env_var(env: &str) -> Result<String> {
-    std::env::var(env).wrap_err("{env} is not set")
+    std::env::var(env).wrap_err(format!("{env} is not set"))
 }
 
 pub fn load_from_file<T: DeserializeOwned>(path: &str) -> Result<T> {


### PR DESCRIPTION
Without formatting, it produces error msg like this

```
Error: 
   0: {env} is not set
   1: environment variable not found
```