### PR TITLE
docs: Improving clarity by fixing some minor typos

### DIFF
--- a/docs/docs/developing/commit-module.md
+++ b/docs/docs/developing/commit-module.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Commit Module
 
-While a module can be written in any language, we currently provide some utils for Rust, with the goal of supporting more generalized APIs and simplify development in languages other than Rust.
+While a module can be written in any language, we currently provide some utilities for Rust, with the goal of supporting more generalized APIs and simplifying development in languages other than Rust.
 
 :::note
 Commit-Boost is still in alpha development, all APIs are subject to change
@@ -25,7 +25,7 @@ use commit_boost::prelude::*;
 ## Config
 Your module will likely need a configuration for the Node Operator to customize. This will have to be in the `cb-config.toml` file, in the correct `[[module]]` section. In the module, you can define and load your config as follows.
 
-First define all the parameters needed in a struct:
+First, define all the parameters needed in a struct:
 ```rust
 #[derive(Debug, Deserialize)]
 struct ExtraConfig {
@@ -56,7 +56,7 @@ struct Datagram {
 }
 ```
 
-Furthermore, in order to request a signature, we'd need a public key of the validator. You can get a list of available keys by calling:
+Furthermore, to request a signature, we'd need the public key of the validator. You can get a list of available keys by calling:
 ```rust
 let pubkeys = config.signer_client.get_pubkeys().await.unwrap();
 ```
@@ -109,7 +109,7 @@ You can use the `prometheus` crate to create a custom registry and metrics, for 
 
 ```rust
 static ref MY_CUSTOM_REGISTRY: Registry = Registry::new_custom(Some("da_commit".to_string()), None).unwrap();
-static ref SIG_RECEIVED_COUNTER: IntCounter = IntCounter::new("signature_received", "successful signatures requests received").unwrap();
+static ref SIG_RECEIVED_COUNTER: IntCounter = IntCounter::new("signature_received", "successful signature requests received").unwrap();
 ```
 
 ### Start Metrics Provider
@@ -125,4 +125,4 @@ All that is left is to use the metrics throughout your code:
 ```rust
 SIG_RECEIVED_COUNTER.inc();
 ```
-These will automatically scraped by the Prometheus service running, and exposed on port `9090`. We plan to allow developers to ship pre-made dashboards together with their modules, to allow Node Operators to have an improved oversight on the modules they are running.
+These will be automatically scraped by the Prometheus service running, and exposed on port `9090`. We plan to allow developers to ship pre-made dashboards together with their modules, to allow Node Operators to have an improved oversight on the modules they are running.


### PR DESCRIPTION
Hi, while checking the documentations, I found minor spelling or grammatical issues which shall be fixed for a better clarity.

No tests is needed because only doc is modified.