### PR TITLE
chore(typo): `event_publiher` -> `event_publisher`

### DIFF
--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -97,7 +97,7 @@ pub struct PbsModuleConfig {
     /// Signer client to call Signer API
     pub signer_client: Option<SignerClient>,
     /// Event publisher
-    pub event_publiher: Option<BuilderEventPublisher>,
+    pub event_publisher: Option<BuilderEventPublisher>,
 }
 
 fn default_pbs() -> String {
@@ -117,7 +117,7 @@ pub fn load_pbs_config() -> Result<PbsModuleConfig> {
         pbs_config: Arc::new(config.pbs.pbs_config),
         relays: relay_clients,
         signer_client: None,
-        event_publiher: maybe_publiher,
+        event_publisher: maybe_publiher,
     })
 }
 
@@ -161,7 +161,7 @@ pub fn load_pbs_custom_config<T: DeserializeOwned>() -> Result<(PbsModuleConfig,
             pbs_config: Arc::new(cb_config.pbs.static_config.pbs_config),
             relays: relay_clients,
             signer_client,
-            event_publiher: maybe_publiher,
+            event_publisher: maybe_publiher,
         },
         cb_config.pbs.extra,
     ))

--- a/crates/pbs/src/service.rs
+++ b/crates/pbs/src/service.rs
@@ -21,7 +21,7 @@ impl PbsService {
     pub async fn run<S: BuilderApiState, A: BuilderApi<S>>(state: PbsState<S>) -> Result<()> {
         let address = SocketAddr::from(([0, 0, 0, 0], state.config.pbs_config.port));
         let events_subs =
-            state.config.event_publiher.as_ref().map(|e| e.n_subscribers()).unwrap_or_default();
+            state.config.event_publisher.as_ref().map(|e| e.n_subscribers()).unwrap_or_default();
         info!(?address, events_subs, chain =? state.config.chain, "Starting PBS service");
 
         let app = create_app_router::<S, A>(state);

--- a/crates/pbs/src/state.rs
+++ b/crates/pbs/src/state.rs
@@ -53,7 +53,7 @@ where
     S: BuilderApiState,
 {
     pub fn publish_event(&self, e: BuilderEvent) {
-        if let Some(publisher) = self.config.event_publiher.as_ref() {
+        if let Some(publisher) = self.config.event_publisher.as_ref() {
             publisher.publish(e);
         }
     }

--- a/tests/tests/pbs_integration.rs
+++ b/tests/tests/pbs_integration.rs
@@ -36,7 +36,7 @@ fn to_pbs_config(chain: Chain, pbs_config: PbsConfig, relays: Vec<RelayClient>) 
         chain,
         pbs_config: Arc::new(pbs_config),
         signer_client: None,
-        event_publiher: None,
+        event_publisher: None,
         relays,
     }
 }


### PR DESCRIPTION
If such PRs are unwanted feel free to close this! Just noticed it while browsing the code