### PR TITLE
feat(signer): add ERC2335 ProxyStore

### DIFF
--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -9,7 +9,8 @@ use cb_common::{
         CommitBoostConfig, LogsSettings, ModuleKind, BUILDER_PORT_ENV, BUILDER_URLS_ENV,
         CHAIN_SPEC_ENV, CONFIG_DEFAULT, CONFIG_ENV, JWTS_ENV, LOGS_DIR_DEFAULT, LOGS_DIR_ENV,
         METRICS_PORT_ENV, MODULE_ID_ENV, MODULE_JWT_ENV, PBS_ENDPOINT_ENV, PBS_MODULE_NAME,
-        PROXY_DIR_DEFAULT, PROXY_DIR_ENV, SIGNER_DEFAULT, SIGNER_DIR_KEYS_DEFAULT,
+        PROXY_DIR_DEFAULT, PROXY_DIR_ENV, PROXY_DIR_KEYS_DEFAULT, PROXY_DIR_KEYS_ENV,
+        PROXY_DIR_SECRETS_DEFAULT, PROXY_DIR_SECRETS_ENV, SIGNER_DEFAULT, SIGNER_DIR_KEYS_DEFAULT,
         SIGNER_DIR_KEYS_ENV, SIGNER_DIR_SECRETS_DEFAULT, SIGNER_DIR_SECRETS_ENV, SIGNER_KEYS_ENV,
         SIGNER_MODULE_NAME, SIGNER_PORT_ENV, SIGNER_URL_ENV,
     },
@@ -347,6 +348,23 @@ pub fn handle_docker_init(config_path: String, output_dir: String) -> Result<()>
                             PROXY_DIR_DEFAULT
                         )));
                         let (k, v) = get_env_val(PROXY_DIR_ENV, PROXY_DIR_DEFAULT);
+                        signer_envs.insert(k, v);
+                    }
+                    ProxyStore::ERC2335 { keys_path, secrets_path } => {
+                        volumes.push(Volumes::Simple(format!(
+                            "{}:{}:rw",
+                            keys_path.display(),
+                            PROXY_DIR_KEYS_DEFAULT
+                        )));
+                        let (k, v) = get_env_val(PROXY_DIR_KEYS_ENV, PROXY_DIR_KEYS_DEFAULT);
+                        signer_envs.insert(k, v);
+
+                        volumes.push(Volumes::Simple(format!(
+                            "{}:{}:rw",
+                            secrets_path.display(),
+                            PROXY_DIR_SECRETS_DEFAULT
+                        )));
+                        let (k, v) = get_env_val(PROXY_DIR_SECRETS_ENV, PROXY_DIR_SECRETS_DEFAULT);
                         signer_envs.insert(k, v);
                     }
                 }

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -45,9 +45,15 @@ pub const SIGNER_DIR_KEYS_DEFAULT: &str = "/keys";
 /// Path to `secrets` folder
 pub const SIGNER_DIR_SECRETS_ENV: &str = "CB_SIGNER_LOADER_SECRETS_DIR";
 pub const SIGNER_DIR_SECRETS_DEFAULT: &str = "/secrets";
-/// Path to store proxies
+/// Path to store proxies with plaintext keys (testing only)
 pub const PROXY_DIR_ENV: &str = "CB_PROXY_STORE_DIR";
 pub const PROXY_DIR_DEFAULT: &str = "/proxies";
+/// Path to store proxy keys
+pub const PROXY_DIR_KEYS_ENV: &str = "CB_PROXY_KEYS_DIR";
+pub const PROXY_DIR_KEYS_DEFAULT: &str = "/proxy_keys";
+/// Path to store proxy secrets
+pub const PROXY_DIR_SECRETS_ENV: &str = "CB_PROXY_SECRETS_DIR";
+pub const PROXY_DIR_SECRETS_DEFAULT: &str = "/proxy_secrets";
 
 ///////////////////////// MODULES /////////////////////////
 

--- a/crates/common/src/signer/loader.rs
+++ b/crates/common/src/signer/loader.rs
@@ -105,7 +105,7 @@ fn load_secrets_and_keys(
     Ok(signers)
 }
 
-fn load_one(ks_path: String, pw_path: String) -> eyre::Result<ConsensusSigner> {
+pub fn load_one(ks_path: String, pw_path: String) -> eyre::Result<ConsensusSigner> {
     let keystore = Keystore::from_json_file(ks_path).map_err(|_| eyre!("failed reading json"))?;
     let password = fs::read(pw_path)?;
     let key =


### PR DESCRIPTION
This PR implements a new way to safely store proxy keys using ERC-2335 format. It saves (and reads) the keys and secrets using the following structure:

```
PROXY_DIR_KEYS_ENV
└── <CONSENSUS_PUBKEY>
    ├── <MODULE1_ID>.json
    ├── <MODULE1_ID>.sig
    ├── <MODULE2_ID>.json
    └── <MODULE2_ID>.sig
PROXY_DIR_SECRETS_ENV
└── <CONSENSUS_PUBKEY>
    ├── <MODULE1_ID>
    └── <MODULE2_ID>
```

Storing in the `.sig` file the delegation signature

Close #71