### PR TITLE
Public necessary type for custom pbs pipeline

### DIFF
--- a/crates/common/src/pbs/types/kzg.rs
+++ b/crates/common/src/pbs/types/kzg.rs
@@ -94,7 +94,7 @@ impl FromStr for KzgCommitment {
 }
 
 // PROOF
-const BYTES_PER_PROOF: usize = 48;
+pub const BYTES_PER_PROOF: usize = 48;
 
 #[derive(Debug, Clone)]
 pub struct KzgProof(pub [u8; BYTES_PER_PROOF]);

--- a/crates/common/src/pbs/types/mod.rs
+++ b/crates/common/src/pbs/types/mod.rs
@@ -7,8 +7,17 @@ mod kzg;
 mod spec;
 mod utils;
 
-pub use beacon_block::{SignedBlindedBeaconBlock, SubmitBlindedBlockResponse};
-pub use execution_payload::{Transaction, EMPTY_TX_ROOT_HASH};
-pub use get_header::{GetHeaderParams, GetHeaderResponse, SignedExecutionPayloadHeader};
+pub use beacon_block::{PayloadAndBlobs, SignedBlindedBeaconBlock, SubmitBlindedBlockResponse};
+pub use blobs_bundle::{Blob, BlobsBundle};
+pub use execution_payload::{
+    ExecutionPayload, ExecutionPayloadHeader, Transaction, Transactions, Withdrawal,
+    EMPTY_TX_ROOT_HASH,
+};
+pub use get_header::{
+    ExecutionPayloadHeaderMessage, GetHeaderParams, GetHeaderResponse, SignedExecutionPayloadHeader,
+};
+pub use kzg::{
+    KzgCommitment, KzgCommitments, KzgProof, KzgProofs, BYTES_PER_COMMITMENT, BYTES_PER_PROOF,
+};
 pub use spec::{DenebSpec, EthSpec};
 pub use utils::{Version, VersionedResponse};


### PR DESCRIPTION
We are working on a custom pbs module, we need to construct the buider api response when we do fallback block builder, some pbs types need to be public.