### PR TITLE
remove default mux relay

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -116,12 +116,12 @@ validator_pubkeys = [
 loader = "./mux_keys.example.json"
 timeout_get_header_ms = 900
 late_in_slot_time_ms = 1500
-# For each mux, one or more [[pbs_mux.relays]] can be defined, which will be used for the matching validator pubkeys
-# Only the relays defined here will be used, and the rest of the relays defined in the main config will be ignored
-# Any field defined here will override the default value from the relay config with the same id in [[relays]]
+# For each mux, one or more [[mux.relays]] can be defined, which will be used for the matching validator pubkeys
+# Only the relays defined here will be used, and the relays defined in the main [[relays]] config will be ignored
+# The fields specified here are the same as in [[relays]] (headers, enable_timing_games, target_first_request_ms, frequency_get_header_ms)
 [[mux.relays]]
-id = "example-relay"
-headers = { X-MyCustomHeader = "ADifferentCustomValue" }
+id = "mux-relay-1"
+url = "http://0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09fe73ccd21f88eab31d6de16194d17782e@def.xyz"
 
 # Configuration for the Signer Module, only required if any `commit` module is present, or if `pbs.with_signer = true`
 # Currently two types of Signer modules are supported (only one can be used at a time):

--- a/configs/pbs-mux.toml
+++ b/configs/pbs-mux.toml
@@ -7,18 +7,14 @@ port = 18550
 timeout_get_header_ms = 950
 late_in_slot_time_ms = 2000
 
+# Used for all validators except the ones in the mux
 [[relays]]
 id = "relay-1"
 url = "http://0xa1cec75a3f0661e99299274182938151e8433c61a19222347ea1313d839229cb4ce4e3e5aa2bdeb71c8fcf1b084963c2@abc.xyz"
 
-[[relays]]
-id = "relay-2"
-url = "http://0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09fe73ccd21f88eab31d6de16194d17782e@def.xyz"
-enable_timing_games = true
-target_first_request_ms = 200
 
 [[mux]]
-id = "test_mux"
+id = "timing-mux"
 validator_pubkeys = [
     "0x80c7f782b2467c5898c5516a8b6595d75623960b4afc4f71ee07d40985d20e117ba35e7cd352a3e75fb85a8668a3b745",
 ]
@@ -28,4 +24,6 @@ late_in_slot_time_ms = 1500
 
 [[mux.relays]]
 id = "relay-2"
-enable_timing_games = false
+url = "http://0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09fe73ccd21f88eab31d6de16194d17782e@def.xyz"
+enable_timing_games = true
+target_first_request_ms = 200

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -181,10 +181,8 @@ pub fn load_pbs_config() -> Result<PbsModuleConfig> {
         SocketAddr::from((config.pbs.pbs_config.host, config.pbs.pbs_config.port))
     };
 
-    let muxes = config
-        .muxes
-        .map(|muxes| muxes.validate_and_fill(&config.pbs.pbs_config, &config.relays))
-        .transpose()?;
+    let muxes =
+        config.muxes.map(|muxes| muxes.validate_and_fill(&config.pbs.pbs_config)).transpose()?;
 
     let relay_clients =
         config.relays.into_iter().map(RelayClient::new).collect::<Result<Vec<_>>>()?;
@@ -234,9 +232,7 @@ pub fn load_pbs_custom_config<T: DeserializeOwned>() -> Result<(PbsModuleConfig,
     };
 
     let muxes = match cb_config.muxes {
-        Some(muxes) => Some(
-            muxes.validate_and_fill(&cb_config.pbs.static_config.pbs_config, &cb_config.relays)?,
-        ),
+        Some(muxes) => Some(muxes.validate_and_fill(&cb_config.pbs.static_config.pbs_config)?),
         None => None,
     };
 


### PR DESCRIPTION
Remove default relays from mux , now relays configs have to be specified fully in the `[[mux.relays]]` section

fix #204 