### PR TITLE
Fix: typos in documentation

### DIFF
--- a/benches/pbs/README.md
+++ b/benches/pbs/README.md
@@ -94,7 +94,7 @@ commit-boost-cli start --docker benches/pbs/bench.docker-compose.yml
 ```
 or regenerate it using `commit-boost-cli init`.
 
-To clean up after then benchmark, run:
+To clean up after the benchmark, run:
 ```bash
 commit-boost-cli stop --docker benches/pbs/bench.docker-compose.yml
 ```

--- a/docs/docs/get_started/running/binary.md
+++ b/docs/docs/get_started/running/binary.md
@@ -39,7 +39,7 @@ Modules need some environment variables to work correctly.
 
 #### Commit modules
 - `CB_SIGNER_URL`: required, url to the signer module server.
-- `CB_SIGNER_JWT`: required, jwt to use to for signature requests (needs to match what is in `CB_JWTS`).
+- `CB_SIGNER_JWT`: required, jwt to use for signature requests (needs to match what is in `CB_JWTS`).
 
 #### Events modules
 - `CB_BUILDER_PORT`: required, port to open to receive builder events from the PBS module.


### PR DESCRIPTION
This pull request fixes minor typos in the project documentation to improve clarity and readability. Below are the changes made:

1. In `benches/pbs/README.md`, corrected "then benchmark" to "the benchmark" for grammatical accuracy.
2. In `docs/docs/get_started/running/binary.md`, fixed "to use to for" to "to use for" to remove redundancy.