### PR TITLE
feat(mux): add successful num_registrations to logs

### DIFF
--- a/crates/pbs/src/api.rs
+++ b/crates/pbs/src/api.rs
@@ -45,7 +45,7 @@ pub trait BuilderApi<S: BuilderApiState>: 'static {
         registrations: Vec<ValidatorRegistration>,
         req_headers: HeaderMap,
         state: PbsState<S>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<usize> {
         mev_boost::register_validator(registrations, req_headers, state).await
     }
 }


### PR DESCRIPTION
For each validator, log the number of relays where it was successfully registered, if `wait_all_registrations` config is `true`.

#218 

> [!WARNING]
> This changes the Eth Builder API in order to return that number. If this is not ideal, we can otherwise log the number of relays where the validator **attempted** to register