### PR TITLE
Init tracing log should use provided log_dir_path

### DIFF
--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -18,7 +18,7 @@ use tracing_appender::{non_blocking::WorkerGuard, rolling::Rotation};
 use tracing_subscriber::{fmt::Layer, prelude::*, EnvFilter};
 
 use crate::{
-    config::{load_optional_env_var, LogsSettings, LOGS_DIR_DEFAULT, PBS_MODULE_NAME},
+    config::{load_optional_env_var, LogsSettings, PBS_MODULE_NAME},
     pbs::HEADER_VERSION_VALUE,
     types::Chain,
 };


### PR DESCRIPTION
Correctly pass in `LogsSettings` log_dir_path field for extensibility. If not set or defined it would fallback to default as shown below:
https://github.com/Commit-Boost/commit-boost-client/blob/ae386475957440001e4f4a3d8b7f77678b230469/crates/common/src/config/log.rs#L18-L21

Closes #237 