### PR TITLE
feat(pbs): batch size config for validators registration

### DIFF
--- a/benches/pbs/src/main.rs
+++ b/benches/pbs/src/main.rs
@@ -160,6 +160,7 @@ fn get_mock_validator(bench: BenchConfig) -> RelayClient {
         enable_timing_games: false,
         target_first_request_ms: None,
         frequency_get_header_ms: None,
+        validator_registration_batch_size: None,
     };
 
     RelayClient::new(config).unwrap()

--- a/config.example.toml
+++ b/config.example.toml
@@ -58,9 +58,6 @@ extra_validation_enabled = false
 # Execution Layer RPC url to use for extra validation
 # OPTIONAL
 rpc_url = "https://ethereum-holesky-rpc.publicnode.com"
-# Maximum number of validators to register in a single request to each relay.
-# OPTIONAL, DEFAULT: None (unlimited)
-# validator_registration_batch_size = 1000
 
 # The PBS module needs one or more [[relays]] as defined below.
 [[relays]]
@@ -99,6 +96,9 @@ target_first_request_ms = 200
 # Frequency in ms to send get_header requests
 # OPTIONAL
 frequency_get_header_ms = 300
+# Maximum number of validators to register in a single request.
+# OPTIONAL, DEFAULT: "" (unlimited)
+validator_registration_batch_size = ""
 
 # Configuration for the PBS multiplexers, which enable different configs to be used for get header requests, depending on validator pubkey
 # Note that:

--- a/config.example.toml
+++ b/config.example.toml
@@ -58,6 +58,9 @@ extra_validation_enabled = false
 # Execution Layer RPC url to use for extra validation
 # OPTIONAL
 rpc_url = "https://ethereum-holesky-rpc.publicnode.com"
+# Maximum number of validators to register in a single request to each relay.
+# OPTIONAL, DEFAULT: None (unlimited)
+# validator_registration_batch_size = 1000
 
 # The PBS module needs one or more [[relays]] as defined below.
 [[relays]]

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -50,6 +50,28 @@ pub struct RelayConfig {
     pub target_first_request_ms: Option<u64>,
     /// Frequency in ms to send get_header requests
     pub frequency_get_header_ms: Option<u64>,
+    /// Maximum number of validators to send to relays in one registration
+    /// request
+    #[serde(deserialize_with = "empty_string_as_none")]
+    pub validator_registration_batch_size: Option<usize>,
+}
+
+fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Helper {
+        Str(String),
+        Number(usize),
+    }
+
+    match Helper::deserialize(deserializer)? {
+        Helper::Str(str) if str.is_empty() => Ok(None),
+        Helper::Number(number) => Ok(Some(number)),
+        _ => Err(serde::de::Error::custom(format!("Expected empty string or number"))),
+    }
 }
 
 impl RelayConfig {
@@ -98,28 +120,6 @@ pub struct PbsConfig {
     pub extra_validation_enabled: bool,
     /// Execution Layer RPC url to use for extra validation
     pub rpc_url: Option<Url>,
-    /// Maximum number of validators to send to relays in one registration
-    /// request
-    #[serde(deserialize_with = "empty_string_as_none")]
-    pub validator_registration_batch_size: Option<usize>,
-}
-
-fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Helper {
-        Str(String),
-        Number(usize),
-    }
-
-    match Helper::deserialize(deserializer)? {
-        Helper::Str(str) if str.is_empty() => Ok(None),
-        Helper::Number(number) => Ok(Some(number)),
-        _ => Err(serde::de::Error::custom(format!("Expected empty string or number"))),
-    }
 }
 
 impl PbsConfig {

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -100,7 +100,26 @@ pub struct PbsConfig {
     pub rpc_url: Option<Url>,
     /// Maximum number of validators to send to relays in one registration
     /// request
+    #[serde(deserialize_with = "empty_string_as_none")]
     pub validator_registration_batch_size: Option<usize>,
+}
+
+fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Helper {
+        Str(String),
+        Number(usize),
+    }
+
+    match Helper::deserialize(deserializer)? {
+        Helper::Str(str) if str.is_empty() => Ok(None),
+        Helper::Number(number) => Ok(Some(number)),
+        _ => Err(serde::de::Error::custom(format!("Expected empty string or number"))),
+    }
 }
 
 impl PbsConfig {

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -98,6 +98,9 @@ pub struct PbsConfig {
     pub extra_validation_enabled: bool,
     /// Execution Layer RPC url to use for extra validation
     pub rpc_url: Option<Url>,
+    /// Maximum number of validators to send to relays in one registration
+    /// request
+    pub validator_registration_batch_size: Option<usize>,
 }
 
 impl PbsConfig {

--- a/crates/pbs/src/mev_boost/register_validator.rs
+++ b/crates/pbs/src/mev_boost/register_validator.rs
@@ -32,18 +32,31 @@ pub async fn register_validator<S: BuilderApiState>(
         .insert(HEADER_START_TIME_UNIX_MS, HeaderValue::from_str(&utcnow_ms().to_string())?);
     send_headers.insert(USER_AGENT, get_user_agent_with_version(&req_headers)?);
 
+    let validator_batches = registrations
+        .chunks(
+            state
+                .config
+                .pbs_config
+                .validator_registration_batch_size
+                .unwrap_or(registrations.len()),
+        )
+        .map(|chunk| chunk.to_vec())
+        .collect::<Vec<Vec<ValidatorRegistration>>>();
+
     let relays = state.all_relays().to_vec();
     let mut handles = Vec::with_capacity(relays.len());
-    for relay in relays {
-        handles.push(tokio::spawn(
-            send_register_validator_with_timeout(
-                registrations.clone(),
-                relay,
-                send_headers.clone(),
-                state.pbs_config().timeout_register_validator_ms,
-            )
-            .in_current_span(),
-        ));
+    for batch in validator_batches {
+        for relay in relays.clone() {
+            handles.push(tokio::spawn(
+                send_register_validator_with_timeout(
+                    batch.clone(),
+                    relay,
+                    send_headers.clone(),
+                    state.pbs_config().timeout_register_validator_ms,
+                )
+                .in_current_span(),
+            ));
+        }
     }
 
     if state.pbs_config().wait_all_registrations {

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -28,6 +28,7 @@ pub fn generate_mock_relay(port: u16, pubkey: BlsPublicKey) -> Result<RelayClien
         enable_timing_games: false,
         target_first_request_ms: None,
         frequency_get_header_ms: None,
+        validator_registration_batch_size: None,
     };
     RelayClient::new(config)
 }

--- a/tests/tests/pbs_integration.rs
+++ b/tests/tests/pbs_integration.rs
@@ -38,7 +38,6 @@ fn get_pbs_static_config(port: u16) -> PbsConfig {
         relay_monitors: vec![],
         extra_validation_enabled: false,
         rpc_url: None,
-        validator_registration_batch_size: None,
     }
 }
 

--- a/tests/tests/pbs_integration.rs
+++ b/tests/tests/pbs_integration.rs
@@ -38,6 +38,7 @@ fn get_pbs_static_config(port: u16) -> PbsConfig {
         relay_monitors: vec![],
         extra_validation_enabled: false,
         rpc_url: None,
+        validator_registration_batch_size: None,
     }
 }
 


### PR DESCRIPTION
Added a new configuration `validator_registration_batch_size` for relays that splits the validators registration in batches

Close #226 