### PR TITLE
chore: debug relay responses

### DIFF
--- a/crates/common/src/pbs/error.rs
+++ b/crates/common/src/pbs/error.rs
@@ -17,7 +17,7 @@ pub enum PbsError {
     #[error("json decode error: {err:?}, raw: {raw}")]
     JsonDecode { err: serde_json::Error, raw: String },
 
-    #[error("relay response error. Code: {code}, err: {error_msg}")]
+    #[error("relay response error. Code: {code}, err: {error_msg:?}")]
     RelayResponse { error_msg: String, code: u16 },
 
     #[error("response size exceeds max size: max: {max} raw: {raw}")]


### PR DESCRIPTION
before we were using `Display` which was creating some annoying gaps in the stdout logs

Before
```
2025-01-21T16:58:58.807625Z  WARN cb_pbs::mev_boost::submit_block::tests: failed to get payload (this might be ok if other relays have it) err=relay response error. Code: 400, err: {"code":400,"message":"no execution payload for this request - block was never seen by this relay"}
{"code":400,"message":"no execution payload for this request"}

2025-01-21T16:58:58.807733Z  WARN cb_pbs::mev_boost::submit_block::tests: failed to get payload (this might be ok if other relays have it) err=relay response error. Code: 400, err: {"code":400,"message":"no execution payload for this request - block was never seen by this relay"}
{"code":400,"message":"no execution payload for this request"}
```

After
```
2025-01-21T17:01:18.019866Z  WARN cb_pbs::mev_boost::submit_block::tests: failed to get payload (this might be ok if other relays have it) err=relay response error. Code: 400, err: "{\"code\":400,\"message\":\"no execution payload for this request - block was never seen by this relay\"}\n{\"code\":400,\"message\":\"no execution payload for this request\"}\n"
2025-01-21T17:01:18.019920Z  WARN cb_pbs::mev_boost::submit_block::tests: failed to get payload (this might be ok if other relays have it) err=relay response error. Code: 400, err: "{\"code\":400,\"message\":\"no execution payload for this request - block was never seen by this relay\"}\n{\"code\":400,\"message\":\"no execution payload for this request\"}\n"
```