### PR TITLE
chore: remove relay monitor

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -44,9 +44,6 @@ skip_sigverify = false
 # Can be specified as a float or a string for extra precision (e.g. "0.01")
 # OPTIONAL, DEFAULT: 0.0
 min_bid_eth = 0.0
-# List of URLs of relay monitors to send registrations to
-# OPTIONAL
-relay_monitors = []
 # How late in milliseconds in the slot is "late". This impacts the `get_header` requests, by shortening timeouts for `get_header` calls to
 # relays and make sure a header is returned within this deadline. If the request from the CL comes later in the slot, then fetching headers is skipped
 # to force local building and miniminzing the risk of missed slots. See also the timing games section below

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -111,9 +111,6 @@ pub struct PbsConfig {
     /// Minimum bid that will be accepted from get_header
     #[serde(rename = "min_bid_eth", with = "as_eth_str", default = "default_u256")]
     pub min_bid_wei: U256,
-    /// List of relay monitor urls in the form of scheme://host
-    #[serde(default)]
-    pub relay_monitors: Vec<Url>,
     /// How late in the slot we consider to be "late"
     #[serde(default = "default_u64::<LATE_IN_SLOT_TIME_MS>")]
     pub late_in_slot_time_ms: u64,

--- a/crates/pbs/src/routes/register_validator.rs
+++ b/crates/pbs/src/routes/register_validator.rs
@@ -1,14 +1,8 @@
-use std::time::Instant;
-
 use alloy::rpc::types::beacon::relay::ValidatorRegistration;
 use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
-use cb_common::{
-    pbs::{BuilderEvent, REGISTER_VALIDATOR_PATH},
-    utils::get_user_agent,
-    DEFAULT_REQUEST_TIMEOUT,
-};
-use reqwest::{StatusCode, Url};
-use tracing::{debug, error, info, trace};
+use cb_common::{pbs::BuilderEvent, utils::get_user_agent};
+use reqwest::StatusCode;
+use tracing::{error, info, trace};
 use uuid::Uuid;
 
 use crate::{
@@ -34,13 +28,6 @@ pub async fn handle_register_validator<S: BuilderApiState, A: BuilderApi<S>>(
 
     info!(ua, num_registrations = registrations.len());
 
-    if state.has_monitors() {
-        // send registrations to monitors
-        for relay_monitor in state.pbs_config().relay_monitors.clone() {
-            tokio::spawn(send_relay_monitor_registrations(registrations.clone(), relay_monitor));
-        }
-    }
-
     if let Err(err) = A::register_validator(registrations, req_headers, state.clone()).await {
         state.publish_event(BuilderEvent::RegisterValidatorResponse);
         error!(%err, "all relays failed registration");
@@ -55,46 +42,5 @@ pub async fn handle_register_validator<S: BuilderApiState, A: BuilderApi<S>>(
 
         BEACON_NODE_STATUS.with_label_values(&["200", REGISTER_VALIDATOR_ENDPOINT_TAG]).inc();
         Ok(StatusCode::OK)
-    }
-}
-
-#[tracing::instrument(skip_all, name = "monitor", fields(url = relay_monitor_url.host_str().unwrap_or_default()))]
-async fn send_relay_monitor_registrations(
-    registrations: Vec<ValidatorRegistration>,
-    relay_monitor_url: Url,
-) {
-    let Ok(url) = relay_monitor_url.join(REGISTER_VALIDATOR_PATH) else {
-        error!("invalid URL");
-        return;
-    };
-
-    let start_request = Instant::now();
-    let res = match reqwest::Client::new()
-        .post(url)
-        .timeout(DEFAULT_REQUEST_TIMEOUT)
-        .json(&registrations)
-        .send()
-        .await
-    {
-        Ok(res) => res,
-        Err(err) => {
-            error!(%err, "failed monitor registration");
-            return;
-        }
-    };
-    let request_latency = start_request.elapsed();
-
-    let code = res.status();
-    match res.bytes().await {
-        Ok(response_bytes) => {
-            if code.is_success() {
-                debug!(?code, latency = ?request_latency, "relay monitor registration successful");
-            } else {
-                let err = String::from_utf8_lossy(&response_bytes);
-                error!(?code, %err, "failed monitor registration");
-            }
-        }
-
-        Err(err) => error!(%err, "failed to decode monitor response"),
     }
 }

--- a/crates/pbs/src/state.rs
+++ b/crates/pbs/src/state.rs
@@ -69,10 +69,6 @@ where
         }
     }
 
-    pub fn has_monitors(&self) -> bool {
-        !self.config.pbs_config.relay_monitors.is_empty()
-    }
-
     pub fn extra_validation_enabled(&self) -> bool {
         self.config.pbs_config.extra_validation_enabled
     }

--- a/tests/data/configs/pbs.happy.toml
+++ b/tests/data/configs/pbs.happy.toml
@@ -12,7 +12,6 @@ timeout_get_payload_ms = 4000
 timeout_register_validator_ms = 3000
 skip_sigverify = false
 min_bid_eth = 0.5
-relay_monitors = []
 late_in_slot_time_ms = 2000
 extra_validation_enabled = false
 rpc_url = "https://ethereum-holesky-rpc.publicnode.com"

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -68,7 +68,6 @@ pub fn get_pbs_static_config(port: u16) -> PbsConfig {
         skip_sigverify: false,
         min_bid_wei: U256::ZERO,
         late_in_slot_time_ms: u64::MAX,
-        relay_monitors: vec![],
         extra_validation_enabled: false,
         rpc_url: None,
     }

--- a/tests/tests/config.rs
+++ b/tests/tests/config.rs
@@ -45,7 +45,6 @@ async fn test_load_pbs_happy() -> Result<()> {
     dbg!(&config.pbs.pbs_config.min_bid_wei);
     dbg!(&U256::from(0.5));
     assert_eq!(config.pbs.pbs_config.min_bid_wei, U256::from((0.5 * WEI_PER_ETH as f64) as u64));
-    assert!(config.pbs.pbs_config.relay_monitors.is_empty());
     assert_eq!(config.pbs.pbs_config.late_in_slot_time_ms, 2000);
     assert_eq!(config.pbs.pbs_config.extra_validation_enabled, false);
     assert_eq!(


### PR DESCRIPTION
relay monitors were added for backwards compatibility with mev boost but never used in practice. Since they were deprecated in https://github.com/flashbots/mev-boost/pull/739 , removing them here as well