### PR TITLE
feat(signer): use real JWTs for signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,7 @@ dependencies = [
  "ethereum_ssz 0.8.3",
  "ethereum_ssz_derive",
  "eyre",
+ "jsonwebtoken",
  "pbkdf2 0.12.2",
  "rand 0.9.0",
  "reqwest",
@@ -1566,6 +1567,7 @@ dependencies = [
  "eyre",
  "futures",
  "headers",
+ "jsonwebtoken",
  "lazy_static",
  "prometheus",
  "prost",
@@ -2574,8 +2576,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3165,6 +3169,19 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "ring 0.17.14",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,4 @@ typenum = "1.17.0"
 unicode-normalization = "0.1.24"
 url = { version = "2.5.0", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["fast-rng", "serde", "v4"] }
+jsonwebtoken = { version = "9.3.1", default-features = false }

--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -20,7 +20,7 @@ use cb_common::{
     pbs::{BUILDER_API_PATH, GET_STATUS_PATH},
     signer::{ProxyStore, SignerLoader},
     types::ModuleId,
-    utils::random_jwt,
+    utils::create_jwt,
 };
 use docker_compose_types::{
     Compose, DependsCondition, DependsOnOptions, EnvFile, Environment, Healthcheck,
@@ -99,7 +99,7 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
                     let mut ports = vec![];
                     needs_signer_module = true;
 
-                    let jwt = random_jwt();
+                    let jwt = create_jwt(&module.id)?;
                     let jwt_name = format!("CB_JWT_{}", module.id.to_uppercase());
 
                     // module ids are assumed unique, so envs dont override each other

--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -10,12 +10,11 @@ use cb_common::{
         BUILDER_URLS_ENV, CHAIN_SPEC_ENV, CONFIG_DEFAULT, CONFIG_ENV, DIRK_CA_CERT_DEFAULT,
         DIRK_CA_CERT_ENV, DIRK_CERT_DEFAULT, DIRK_CERT_ENV, DIRK_DIR_SECRETS_DEFAULT,
         DIRK_DIR_SECRETS_ENV, DIRK_KEY_DEFAULT, DIRK_KEY_ENV, LOGS_DIR_DEFAULT, LOGS_DIR_ENV,
-        METRICS_PORT_ENV, MODULES_ENV, MODULE_ID_ENV, MODULE_JWT_ENV, PBS_ENDPOINT_ENV,
-        PBS_MODULE_NAME, PROXY_DIR_DEFAULT, PROXY_DIR_ENV, PROXY_DIR_KEYS_DEFAULT,
-        PROXY_DIR_KEYS_ENV, PROXY_DIR_SECRETS_DEFAULT, PROXY_DIR_SECRETS_ENV, SIGNER_DEFAULT,
-        SIGNER_DIR_KEYS_DEFAULT, SIGNER_DIR_KEYS_ENV, SIGNER_DIR_SECRETS_DEFAULT,
-        SIGNER_DIR_SECRETS_ENV, SIGNER_KEYS_ENV, SIGNER_MODULE_NAME, SIGNER_PORT_ENV,
-        SIGNER_URL_ENV,
+        METRICS_PORT_ENV, MODULE_ID_ENV, MODULE_JWT_ENV, PBS_ENDPOINT_ENV, PBS_MODULE_NAME,
+        PROXY_DIR_DEFAULT, PROXY_DIR_ENV, PROXY_DIR_KEYS_DEFAULT, PROXY_DIR_KEYS_ENV,
+        PROXY_DIR_SECRETS_DEFAULT, PROXY_DIR_SECRETS_ENV, SIGNER_DEFAULT, SIGNER_DIR_KEYS_DEFAULT,
+        SIGNER_DIR_KEYS_ENV, SIGNER_DIR_SECRETS_DEFAULT, SIGNER_DIR_SECRETS_ENV, SIGNER_KEYS_ENV,
+        SIGNER_MODULE_NAME, SIGNER_PORT_ENV, SIGNER_URL_ENV,
     },
     pbs::{BUILDER_API_PATH, GET_STATUS_PATH},
     signer::{ProxyStore, SignerLoader},
@@ -329,7 +328,6 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
             SignerType::Local { loader, store } => {
                 let mut signer_envs = IndexMap::from([
                     get_env_val(CONFIG_ENV, CONFIG_DEFAULT),
-                    get_env_same(MODULES_ENV),
                     get_env_uval(SIGNER_PORT_ENV, signer_port as u64),
                 ]);
 
@@ -353,12 +351,6 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
                     let (key, val) = get_env_val(LOGS_DIR_ENV, LOGS_DIR_DEFAULT);
                     signer_envs.insert(key, val);
                 }
-
-                // write modules to env
-                envs.insert(
-                    MODULES_ENV.into(),
-                    jwts.keys().map(|module| module.0.clone()).collect::<Vec<_>>().join(","),
-                );
 
                 // volumes
                 let mut volumes = vec![config_volume.clone()];
@@ -457,7 +449,6 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
             SignerType::Dirk { cert_path, key_path, secrets_path, ca_cert_path, store, .. } => {
                 let mut signer_envs = IndexMap::from([
                     get_env_val(CONFIG_ENV, CONFIG_DEFAULT),
-                    get_env_same(MODULES_ENV),
                     get_env_uval(SIGNER_PORT_ENV, signer_port as u64),
                     get_env_val(DIRK_CERT_ENV, DIRK_CERT_DEFAULT),
                     get_env_val(DIRK_KEY_ENV, DIRK_KEY_DEFAULT),
@@ -484,12 +475,6 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
                     let (key, val) = get_env_val(LOGS_DIR_ENV, LOGS_DIR_DEFAULT);
                     signer_envs.insert(key, val);
                 }
-
-                // write modules to env
-                envs.insert(
-                    MODULES_ENV.into(),
-                    jwts.keys().map(|module| module.0.clone()).collect::<Vec<_>>().join(","),
-                );
 
                 // volumes
                 let mut volumes = vec![
@@ -637,6 +622,7 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
 }
 
 /// FOO=${FOO}
+#[allow(dead_code)]
 fn get_env_same(k: &str) -> (String, Option<SingleValue>) {
     get_env_interp(k, k)
 }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -40,3 +40,4 @@ tree_hash.workspace = true
 tree_hash_derive.workspace = true
 unicode-normalization.workspace = true
 url.workspace = true
+jsonwebtoken.workspace = true

--- a/crates/common/src/commit/constants.rs
+++ b/crates/common/src/commit/constants.rs
@@ -3,3 +3,4 @@ pub const REQUEST_SIGNATURE_PATH: &str = "/signer/v1/request_signature";
 pub const GENERATE_PROXY_KEY_PATH: &str = "/signer/v1/generate_proxy_key";
 pub const STATUS_PATH: &str = "/status";
 pub const RELOAD_PATH: &str = "/reload";
+pub const REFRESH_TOKEN_PATH: &str = "/refresh_token";

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -35,9 +35,6 @@ pub const SIGNER_MODULE_NAME: &str = "signer";
 /// Where the signer module should open the server
 pub const SIGNER_PORT_ENV: &str = "CB_SIGNER_PORT";
 
-/// Comma separated list of module ids
-pub const MODULES_ENV: &str = "CB_MODULES";
-
 /// Path to json file with plaintext keys (testing only)
 pub const SIGNER_KEYS_ENV: &str = "CB_SIGNER_LOADER_FILE";
 pub const SIGNER_DEFAULT: &str = "/keys.json";

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -35,6 +35,9 @@ pub const SIGNER_MODULE_NAME: &str = "signer";
 /// Where the signer module should open the server
 pub const SIGNER_PORT_ENV: &str = "CB_SIGNER_PORT";
 
+/// The JWT secret for the signer to validate the modules requests
+pub const SIGNER_JWT_SECRET_ENV: &str = "CB_SIGNER_JWT_SECRET";
+
 /// Path to json file with plaintext keys (testing only)
 pub const SIGNER_KEYS_ENV: &str = "CB_SIGNER_LOADER_FILE";
 pub const SIGNER_DEFAULT: &str = "/keys.json";

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -35,8 +35,8 @@ pub const SIGNER_MODULE_NAME: &str = "signer";
 /// Where the signer module should open the server
 pub const SIGNER_PORT_ENV: &str = "CB_SIGNER_PORT";
 
-/// Comma separated list module_id=jwt_secret
-pub const JWTS_ENV: &str = "CB_JWTS";
+/// Comma separated list of module ids
+pub const MODULES_ENV: &str = "CB_MODULES";
 
 /// Path to json file with plaintext keys (testing only)
 pub const SIGNER_KEYS_ENV: &str = "CB_SIGNER_LOADER_FILE";

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -1,20 +1,18 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
-use bimap::BiHashMap;
 use eyre::{bail, OptionExt, Result};
 use serde::{Deserialize, Serialize};
 use tonic::transport::{Certificate, Identity};
 use url::Url;
 
 use super::{
-    constants::SIGNER_IMAGE_DEFAULT,
-    utils::{load_env_var, load_jwts},
-    CommitBoostConfig, SIGNER_PORT_ENV,
+    constants::SIGNER_IMAGE_DEFAULT, load_modules, utils::load_env_var, CommitBoostConfig,
+    SIGNER_PORT_ENV,
 };
 use crate::{
     config::{DIRK_CA_CERT_ENV, DIRK_CERT_ENV, DIRK_DIR_SECRETS_ENV, DIRK_KEY_ENV},
     signer::{ProxyStore, SignerLoader},
-    types::{Chain, Jwt, ModuleId},
+    types::{Chain, ModuleId},
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -90,7 +88,7 @@ pub struct StartSignerConfig {
     pub loader: Option<SignerLoader>,
     pub store: Option<ProxyStore>,
     pub server_port: u16,
-    pub jwts: BiHashMap<ModuleId, Jwt>,
+    pub modules: HashSet<ModuleId>,
     pub dirk: Option<DirkConfig>,
 }
 
@@ -98,7 +96,7 @@ impl StartSignerConfig {
     pub fn load_from_env() -> Result<Self> {
         let config = CommitBoostConfig::from_env_path()?;
 
-        let jwts = load_jwts()?;
+        let modules = load_modules()?;
         let server_port = load_env_var(SIGNER_PORT_ENV)?.parse()?;
 
         let signer = config.signer.ok_or_eyre("Signer config is missing")?.inner;
@@ -108,7 +106,7 @@ impl StartSignerConfig {
                 chain: config.chain,
                 loader: Some(loader),
                 server_port,
-                jwts,
+                modules,
                 store,
                 dirk: None,
             }),
@@ -136,7 +134,7 @@ impl StartSignerConfig {
                 Ok(StartSignerConfig {
                     chain: config.chain,
                     server_port,
-                    jwts,
+                    modules,
                     loader: None,
                     store,
                     dirk: Some(DirkConfig {

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -6,8 +6,7 @@ use tonic::transport::{Certificate, Identity};
 use url::Url;
 
 use super::{
-    constants::SIGNER_IMAGE_DEFAULT, load_modules, utils::load_env_var, CommitBoostConfig,
-    SIGNER_PORT_ENV,
+    constants::SIGNER_IMAGE_DEFAULT, utils::load_env_var, CommitBoostConfig, SIGNER_PORT_ENV,
 };
 use crate::{
     config::{DIRK_CA_CERT_ENV, DIRK_CERT_ENV, DIRK_DIR_SECRETS_ENV, DIRK_KEY_ENV},
@@ -96,7 +95,8 @@ impl StartSignerConfig {
     pub fn load_from_env() -> Result<Self> {
         let config = CommitBoostConfig::from_env_path()?;
 
-        let modules = load_modules()?;
+        let modules =
+            config.modules.unwrap_or(Vec::new()).iter().map(|module| module.id.clone()).collect();
         let server_port = load_env_var(SIGNER_PORT_ENV)?.parse()?;
 
         let signer = config.signer.ok_or_eyre("Signer config is missing")?.inner;

--- a/crates/common/src/config/utils.rs
+++ b/crates/common/src/config/utils.rs
@@ -1,11 +1,10 @@
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
-use bimap::BiHashMap;
-use eyre::{bail, Context, Ok, Result};
+use eyre::{Context, Ok, Result};
 use serde::de::DeserializeOwned;
 
-use super::constants::JWTS_ENV;
-use crate::types::{Jwt, ModuleId};
+use super::MODULES_ENV;
+use crate::types::ModuleId;
 
 pub fn load_env_var(env: &str) -> Result<String> {
     std::env::var(env).wrap_err(format!("{env} is not set"))
@@ -25,24 +24,10 @@ pub fn load_file_from_env<T: DeserializeOwned>(env: &str) -> Result<T> {
     load_from_file(&path)
 }
 
-/// Loads a bidirectional map of module id <-> jwt token from a json env
-pub fn load_jwts() -> Result<BiHashMap<ModuleId, Jwt>> {
-    let jwts = std::env::var(JWTS_ENV).wrap_err(format!("{JWTS_ENV} is not set"))?;
-    decode_string_to_map(&jwts)
-}
-
-fn decode_string_to_map(raw: &str) -> Result<BiHashMap<ModuleId, Jwt>> {
-    // trim the string and split for comma
-    raw.trim()
-        .split(',')
-        .map(|pair| {
-            let mut parts = pair.trim().split('=');
-            match (parts.next(), parts.next()) {
-                (Some(key), Some(value)) => Ok((ModuleId(key.into()), Jwt(value.into()))),
-                _ => bail!("Invalid key-value pair: {pair}"),
-            }
-        })
-        .collect()
+/// Loads a set of module ids from a comma separated string
+pub fn load_modules() -> Result<HashSet<ModuleId>> {
+    let modules = std::env::var(MODULES_ENV).wrap_err(format!("{MODULES_ENV} is not set"))?;
+    Ok(modules.split(',').map(|id| ModuleId(id.into())).collect())
 }
 
 #[cfg(test)]
@@ -50,12 +35,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_decode_string_to_map() {
-        let raw = " KEY=VALUE , KEY2=value2 ";
+    fn test_load_modules() {
+        std::env::set_var(MODULES_ENV, "module1,module2,module3");
 
-        let map = decode_string_to_map(raw).unwrap();
+        let modules = load_modules().unwrap();
 
-        assert_eq!(map.get_by_left(&ModuleId("KEY".into())), Some(&Jwt("VALUE".into())));
-        assert_eq!(map.get_by_left(&ModuleId("KEY2".into())), Some(&Jwt("value2".into())));
+        assert_eq!(modules.len(), 3);
+        assert!(modules.contains(&ModuleId("module1".into())));
+        assert!(modules.contains(&ModuleId("module2".into())));
+        assert!(modules.contains(&ModuleId("module3".into())));
     }
 }

--- a/crates/common/src/config/utils.rs
+++ b/crates/common/src/config/utils.rs
@@ -1,10 +1,7 @@
-use std::{collections::HashSet, path::Path};
+use std::path::Path;
 
-use eyre::{Context, Ok, Result};
+use eyre::{Context, Result};
 use serde::de::DeserializeOwned;
-
-use super::MODULES_ENV;
-use crate::types::ModuleId;
 
 pub fn load_env_var(env: &str) -> Result<String> {
     std::env::var(env).wrap_err(format!("{env} is not set"))
@@ -22,27 +19,4 @@ pub fn load_from_file<P: AsRef<Path> + std::fmt::Debug, T: DeserializeOwned>(pat
 pub fn load_file_from_env<T: DeserializeOwned>(env: &str) -> Result<T> {
     let path = std::env::var(env).wrap_err(format!("{env} is not set"))?;
     load_from_file(&path)
-}
-
-/// Loads a set of module ids from a comma separated string
-pub fn load_modules() -> Result<HashSet<ModuleId>> {
-    let modules = std::env::var(MODULES_ENV).wrap_err(format!("{MODULES_ENV} is not set"))?;
-    Ok(modules.split(',').map(|id| ModuleId(id.into())).collect())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_load_modules() {
-        std::env::set_var(MODULES_ENV, "module1,module2,module3");
-
-        let modules = load_modules().unwrap();
-
-        assert_eq!(modules.len(), 3);
-        assert!(modules.contains(&ModuleId("module1".into())));
-        assert!(modules.contains(&ModuleId("module2".into())));
-        assert!(modules.contains(&ModuleId("module3".into())));
-    }
 }

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -280,14 +280,14 @@ pub struct JwtClaims {
 }
 
 /// Create a JWT for the given module id with a 5 minutes expiration
-pub fn create_jwt(module_id: &ModuleId) -> eyre::Result<String> {
+pub fn create_jwt(module_id: &ModuleId, secret: &str) -> eyre::Result<String> {
     jsonwebtoken::encode(
         &jsonwebtoken::Header::default(),
         &JwtClaims {
             module: module_id.to_string(),
             exp: jsonwebtoken::get_current_timestamp() + 300, // 5 minutes
         },
-        &jsonwebtoken::EncodingKey::from_secret("secret".as_ref()),
+        &jsonwebtoken::EncodingKey::from_secret(secret.as_ref()),
     )
     .map_err(Into::into)
 }

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -26,6 +26,7 @@ tonic.workspace = true
 tracing.workspace = true
 tree_hash.workspace = true
 uuid.workspace = true
+jsonwebtoken.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/signer/src/manager/dirk.rs
+++ b/crates/signer/src/manager/dirk.rs
@@ -82,6 +82,8 @@ struct ProxyAccount {
 pub struct DirkManager {
     /// Chain config for the manager
     chain: Chain,
+    /// Secret used to sign JWTs
+    pub(super) jwt_secret: String,
     /// Consensus accounts available for signing. The key is the public key of
     /// the account.
     consensus_accounts: HashMap<BlsPublicKey, Account>,
@@ -95,7 +97,7 @@ pub struct DirkManager {
 }
 
 impl DirkManager {
-    pub async fn new(chain: Chain, config: DirkConfig) -> eyre::Result<Self> {
+    pub async fn new(chain: Chain, jwt_secret: String, config: DirkConfig) -> eyre::Result<Self> {
         let mut consensus_accounts = HashMap::new();
 
         for host in config.hosts {
@@ -163,6 +165,7 @@ impl DirkManager {
 
         Ok(Self {
             chain,
+            jwt_secret,
             consensus_accounts,
             proxy_accounts: HashMap::new(),
             secrets_path: config.secrets_path,

--- a/crates/signer/src/manager/local.rs
+++ b/crates/signer/src/manager/local.rs
@@ -19,6 +19,8 @@ use crate::error::SignerModuleError;
 #[derive(Clone)]
 pub struct LocalSigningManager {
     chain: Chain,
+    /// Secret used to sign JWTs
+    pub(super) jwt_secret: String,
     proxy_store: Option<ProxyStore>,
     consensus_signers: HashMap<BlsPublicKey, ConsensusSigner>,
     proxy_signers: ProxySigners,
@@ -30,9 +32,14 @@ pub struct LocalSigningManager {
 }
 
 impl LocalSigningManager {
-    pub fn new(chain: Chain, proxy_store: Option<ProxyStore>) -> eyre::Result<Self> {
+    pub fn new(
+        chain: Chain,
+        jwt_secret: String,
+        proxy_store: Option<ProxyStore>,
+    ) -> eyre::Result<Self> {
         let mut manager = Self {
             chain,
+            jwt_secret,
             proxy_store,
             consensus_signers: Default::default(),
             proxy_signers: Default::default(),
@@ -271,13 +278,15 @@ mod tests {
     use super::*;
 
     const CHAIN: Chain = Chain::Holesky;
+    const JWT_SECRET: &str = "secret";
 
     lazy_static! {
         static ref MODULE_ID: ModuleId = ModuleId("SAMPLE_MODULE".to_string());
     }
 
     fn init_signing_manager() -> (LocalSigningManager, BlsPublicKey) {
-        let mut signing_manager = LocalSigningManager::new(CHAIN, None).unwrap();
+        let mut signing_manager =
+            LocalSigningManager::new(CHAIN, JWT_SECRET.to_string(), None).unwrap();
 
         let consensus_signer = ConsensusSigner::new_random();
         let consensus_pk = consensus_signer.pubkey();

--- a/crates/signer/src/manager/mod.rs
+++ b/crates/signer/src/manager/mod.rs
@@ -43,4 +43,11 @@ impl SigningManager {
             }
         }
     }
+
+    pub(super) fn jwt_secret(&self) -> &str {
+        match self {
+            SigningManager::Local(local_manager) => local_manager.jwt_secret.as_str(),
+            SigningManager::Dirk(dirk_manager) => dirk_manager.jwt_secret.as_str(),
+        }
+    }
 }

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -52,22 +52,20 @@ struct SigningState {
 
 impl SigningService {
     pub async fn run(config: StartSignerConfig) -> eyre::Result<()> {
-        if config.jwts.is_empty() {
+        if config.modules.is_empty() {
             warn!("Signing service was started but no module is registered. Exiting");
             return Ok(());
         }
 
-        let module_ids: HashSet<ModuleId> = config.jwts.left_values().cloned().collect();
-
         let state = SigningState {
             manager: Arc::new(RwLock::new(start_manager(config.clone()).await?)),
-            modules: Arc::new(module_ids.clone()),
+            modules: Arc::new(config.modules.clone()),
         };
 
         let loaded_consensus = state.manager.read().await.available_consensus_signers();
         let loaded_proxies = state.manager.read().await.available_proxy_signers();
 
-        info!(version = COMMIT_BOOST_VERSION, commit_hash = COMMIT_BOOST_COMMIT, modules =? module_ids, port =? config.server_port, loaded_consensus, loaded_proxies, "Starting signing service");
+        info!(version = COMMIT_BOOST_VERSION, commit_hash = COMMIT_BOOST_COMMIT, modules =? config.modules, port =? config.server_port, loaded_consensus, loaded_proxies, "Starting signing service");
 
         SigningService::init_metrics(config.chain)?;
 

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -65,7 +65,19 @@ impl SigningService {
         let loaded_consensus = state.manager.read().await.available_consensus_signers();
         let loaded_proxies = state.manager.read().await.available_proxy_signers();
 
-        info!(version = COMMIT_BOOST_VERSION, commit_hash = COMMIT_BOOST_COMMIT, modules =? config.modules, port =? config.server_port, loaded_consensus, loaded_proxies, "Starting signing service");
+        info!(
+            version = COMMIT_BOOST_VERSION,
+            commit_hash = COMMIT_BOOST_COMMIT,
+            modules =? config
+                .modules
+                .iter()
+                .map(|module| module.to_string())
+                .collect::<Vec<String>>(),
+            port =? config.server_port,
+            loaded_consensus,
+            loaded_proxies,
+            "Starting signing service"
+        );
 
         SigningService::init_metrics(config.chain)?;
 


### PR DESCRIPTION
Generate actual JWTs and use them to authenticate requests for the signer. A new `signer.jwt_secret` config and its env var `CB_SIGNER_JWT_SECRET` were added

Close #284 