### PR TITLE
CBST2-04: Update JWT secrets on reload and revoke module endpoint

### DIFF
--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -7,11 +7,11 @@ use std::{
 use cb_common::{
     config::{
         load_optional_env_var, CommitBoostConfig, LogsSettings, ModuleKind, SignerConfig,
-        SignerType, BUILDER_PORT_ENV, BUILDER_URLS_ENV, CHAIN_SPEC_ENV, CONFIG_DEFAULT, CONFIG_ENV,
-        DIRK_CA_CERT_DEFAULT, DIRK_CA_CERT_ENV, DIRK_CERT_DEFAULT, DIRK_CERT_ENV,
-        DIRK_DIR_SECRETS_DEFAULT, DIRK_DIR_SECRETS_ENV, DIRK_KEY_DEFAULT, DIRK_KEY_ENV, JWTS_ENV,
-        LOGS_DIR_DEFAULT, LOGS_DIR_ENV, METRICS_PORT_ENV, MODULE_ID_ENV, MODULE_JWT_ENV,
-        PBS_ENDPOINT_ENV, PBS_MODULE_NAME, PROXY_DIR_DEFAULT, PROXY_DIR_ENV,
+        SignerType, ADMIN_JWT_ENV, BUILDER_PORT_ENV, BUILDER_URLS_ENV, CHAIN_SPEC_ENV,
+        CONFIG_DEFAULT, CONFIG_ENV, DIRK_CA_CERT_DEFAULT, DIRK_CA_CERT_ENV, DIRK_CERT_DEFAULT,
+        DIRK_CERT_ENV, DIRK_DIR_SECRETS_DEFAULT, DIRK_DIR_SECRETS_ENV, DIRK_KEY_DEFAULT,
+        DIRK_KEY_ENV, JWTS_ENV, LOGS_DIR_DEFAULT, LOGS_DIR_ENV, METRICS_PORT_ENV, MODULE_ID_ENV,
+        MODULE_JWT_ENV, PBS_ENDPOINT_ENV, PBS_MODULE_NAME, PROXY_DIR_DEFAULT, PROXY_DIR_ENV,
         PROXY_DIR_KEYS_DEFAULT, PROXY_DIR_KEYS_ENV, PROXY_DIR_SECRETS_DEFAULT,
         PROXY_DIR_SECRETS_ENV, SIGNER_DEFAULT, SIGNER_DIR_KEYS_DEFAULT, SIGNER_DIR_KEYS_ENV,
         SIGNER_DIR_SECRETS_DEFAULT, SIGNER_DIR_SECRETS_ENV, SIGNER_JWT_SECRET_ENV, SIGNER_KEYS_ENV,
@@ -334,6 +334,7 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
                 let mut signer_envs = IndexMap::from([
                     get_env_val(CONFIG_ENV, CONFIG_DEFAULT),
                     get_env_same(JWTS_ENV),
+                    get_env_same(ADMIN_JWT_ENV),
                     get_env_uval(SIGNER_PORT_ENV, signer_port as u64),
                 ]);
 
@@ -360,6 +361,7 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
 
                 // write jwts to env
                 envs.insert(JWTS_ENV.into(), format_comma_separated(&jwts));
+                envs.insert(ADMIN_JWT_ENV.into(), random_jwt_secret());
 
                 // volumes
                 let mut volumes = vec![config_volume.clone()];

--- a/crates/common/src/commit/constants.rs
+++ b/crates/common/src/commit/constants.rs
@@ -3,3 +3,4 @@ pub const REQUEST_SIGNATURE_PATH: &str = "/signer/v1/request_signature";
 pub const GENERATE_PROXY_KEY_PATH: &str = "/signer/v1/generate_proxy_key";
 pub const STATUS_PATH: &str = "/status";
 pub const RELOAD_PATH: &str = "/reload";
+pub const REVOKE_JWT: &str = "/revoke_jwt";

--- a/crates/common/src/commit/constants.rs
+++ b/crates/common/src/commit/constants.rs
@@ -3,4 +3,4 @@ pub const REQUEST_SIGNATURE_PATH: &str = "/signer/v1/request_signature";
 pub const GENERATE_PROXY_KEY_PATH: &str = "/signer/v1/generate_proxy_key";
 pub const STATUS_PATH: &str = "/status";
 pub const RELOAD_PATH: &str = "/reload";
-pub const REVOKE_JWT: &str = "/revoke_jwt";
+pub const REVOKE_MODULE_PATH: &str = "/revoke_jwt";

--- a/crates/common/src/commit/request.rs
+++ b/crates/common/src/commit/request.rs
@@ -14,8 +14,11 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 use crate::{
-    constants::COMMIT_BOOST_DOMAIN, error::BlstErrorWrapper, signature::verify_signed_message,
-    signer::BlsPublicKey, types::Chain,
+    constants::COMMIT_BOOST_DOMAIN,
+    error::BlstErrorWrapper,
+    signature::verify_signed_message,
+    signer::BlsPublicKey,
+    types::{Chain, ModuleId},
 };
 
 pub trait ProxyId: AsRef<[u8]> + Debug + Clone + Copy + TreeHash + Display {}
@@ -198,6 +201,11 @@ pub struct GetPubkeysResponse {
     pub keys: Vec<ConsensusProxyMap>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevokeJWTRequest {
+    pub module_id: ModuleId,
+}
+
 /// Map of consensus pubkeys to proxies
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ConsensusProxyMap {
@@ -288,7 +296,7 @@ mod tests {
 
         let _: SignedProxyDelegationBls = serde_json::from_str(data).unwrap();
 
-        let data = r#"{ 
+        let data = r#"{
             "message": {
                 "delegator": "0xa3366b54f28e4bf1461926a3c70cdb0ec432b5c92554ecaae3742d33fb33873990cbed1761c68020e6d3c14d30a22050",
                 "proxy": "0x4ca9939a8311a7cab3dde201b70157285fa81a9d"

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -37,7 +37,7 @@ pub const SIGNER_PORT_ENV: &str = "CB_SIGNER_PORT";
 
 /// Comma separated list module_id=jwt_secret
 pub const JWTS_ENV: &str = "CB_JWTS";
-pub const ADMIN_JWT_ENV: &str = "CB_ADMIN_JWT";
+pub const ADMIN_JWT_ENV: &str = "CB_SIGNER_ADMIN_JWT";
 /// The JWT secret for the signer to validate the modules requests
 pub const SIGNER_JWT_SECRET_ENV: &str = "CB_SIGNER_JWT_SECRET";
 

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -37,6 +37,7 @@ pub const SIGNER_PORT_ENV: &str = "CB_SIGNER_PORT";
 
 /// Comma separated list module_id=jwt_secret
 pub const JWTS_ENV: &str = "CB_JWTS";
+pub const ADMIN_JWT_ENV: &str = "CB_ADMIN_JWT";
 /// The JWT secret for the signer to validate the modules requests
 pub const SIGNER_JWT_SECRET_ENV: &str = "CB_SIGNER_JWT_SECRET";
 

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -89,6 +89,7 @@ pub struct StartSignerConfig {
     pub store: Option<ProxyStore>,
     pub server_port: u16,
     pub jwts: HashMap<ModuleId, String>,
+    pub admin_secret: String,
     pub dirk: Option<DirkConfig>,
 }
 
@@ -96,7 +97,7 @@ impl StartSignerConfig {
     pub fn load_from_env() -> Result<Self> {
         let config = CommitBoostConfig::from_env_path()?;
 
-        let jwts = load_jwt_secrets()?;
+        let (admin_secret, jwts) = load_jwt_secrets()?;
         let server_port = load_env_var(SIGNER_PORT_ENV)?.parse()?;
 
         let signer = config.signer.ok_or_eyre("Signer config is missing")?.inner;
@@ -107,6 +108,7 @@ impl StartSignerConfig {
                 loader: Some(loader),
                 server_port,
                 jwts,
+                admin_secret,
                 store,
                 dirk: None,
             }),
@@ -135,6 +137,7 @@ impl StartSignerConfig {
                     chain: config.chain,
                     server_port,
                     jwts,
+                    admin_secret,
                     loader: None,
                     store,
                     dirk: Some(DirkConfig {

--- a/crates/common/src/config/utils.rs
+++ b/crates/common/src/config/utils.rs
@@ -31,7 +31,7 @@ pub fn load_jwt_secrets() -> Result<(String, HashMap<ModuleId, String>)> {
     decode_string_to_map(&jwt_secrets).map(|secrets| (admin_jwt, secrets))
 }
 
-fn decode_string_to_map(raw: &str) -> Result<HashMap<ModuleId, String>> {
+pub fn decode_string_to_map(raw: &str) -> Result<HashMap<ModuleId, String>> {
     // trim the string and split for comma
     raw.trim()
         .split(',')

--- a/crates/common/src/config/utils.rs
+++ b/crates/common/src/config/utils.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use eyre::{bail, Context, Result};
 use serde::de::DeserializeOwned;
 
-use super::JWTS_ENV;
+use super::{ADMIN_JWT_ENV, JWTS_ENV};
 use crate::types::ModuleId;
 
 pub fn load_env_var(env: &str) -> Result<String> {
@@ -25,9 +25,10 @@ pub fn load_file_from_env<T: DeserializeOwned>(env: &str) -> Result<T> {
 }
 
 /// Loads a map of module id -> jwt secret from a json env
-pub fn load_jwt_secrets() -> Result<HashMap<ModuleId, String>> {
+pub fn load_jwt_secrets() -> Result<(String, HashMap<ModuleId, String>)> {
+    let admin_jwt = std::env::var(ADMIN_JWT_ENV).wrap_err(format!("{ADMIN_JWT_ENV} is not set"))?;
     let jwt_secrets = std::env::var(JWTS_ENV).wrap_err(format!("{JWTS_ENV} is not set"))?;
-    decode_string_to_map(&jwt_secrets)
+    decode_string_to_map(&jwt_secrets).map(|secrets| (admin_jwt, secrets))
 }
 
 fn decode_string_to_map(raw: &str) -> Result<HashMap<ModuleId, String>> {

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -23,6 +23,12 @@ pub struct JwtClaims {
     pub module: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JwtAdmin {
+    pub exp: u64,
+    pub admin: bool,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Chain {
     Mainnet,

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -26,7 +26,7 @@ use crate::{
     config::LogsSettings,
     constants::SIGNER_JWT_EXPIRATION,
     pbs::HEADER_VERSION_VALUE,
-    types::{Chain, Jwt, JwtClaims, ModuleId},
+    types::{Chain, Jwt, JwtAdmin, JwtClaims, ModuleId},
 };
 
 const MILLIS_PER_SECOND: u64 = 1_000;
@@ -318,6 +318,24 @@ pub fn validate_jwt(jwt: Jwt, secret: &str) -> eyre::Result<()> {
     )
     .map(|_| ())
     .map_err(From::from)
+}
+
+/// Validate an admin JWT with the given secret
+pub fn validate_admin_jwt(jwt: Jwt, secret: &str) -> eyre::Result<()> {
+    let mut validation = jsonwebtoken::Validation::default();
+    validation.leeway = 10;
+
+    let token = jsonwebtoken::decode::<JwtAdmin>(
+        jwt.as_str(),
+        &jsonwebtoken::DecodingKey::from_secret(secret.as_ref()),
+        &validation,
+    )?;
+
+    if token.claims.admin {
+        Ok(())
+    } else {
+        eyre::bail!("Token is not admin")
+    }
 }
 
 /// Generates a random string

--- a/crates/signer/src/error.rs
+++ b/crates/signer/src/error.rs
@@ -25,6 +25,9 @@ pub enum SignerModuleError {
     #[error("Dirk signer does not support this operation")]
     DirkNotSupported,
 
+    #[error("module id not found")]
+    ModuleIdNotFound,
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -45,6 +48,7 @@ impl IntoResponse for SignerModuleError {
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal error".to_string())
             }
             SignerModuleError::SignerError(err) => (StatusCode::BAD_REQUEST, err.to_string()),
+            SignerModuleError::ModuleIdNotFound => (StatusCode::NOT_FOUND, self.to_string()),
         }
         .into_response()
     }

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -270,6 +270,8 @@ async fn handle_reload(
         }
     };
 
+    state.jwts = config.jwts.clone().into();
+
     let new_manager = match start_manager(config).await {
         Ok(manager) => manager,
         Err(err) => {

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -13,7 +13,7 @@ use cb_common::{
     commit::{
         constants::{
             GENERATE_PROXY_KEY_PATH, GET_PUBKEYS_PATH, RELOAD_PATH, REQUEST_SIGNATURE_PATH,
-            REVOKE_JWT, STATUS_PATH,
+            REVOKE_MODULE_PATH, STATUS_PATH,
         },
         request::{
             EncryptionScheme, GenerateProxyRequest, GetPubkeysResponse, RevokeJWTRequest,
@@ -84,7 +84,7 @@ impl SigningService {
 
         let admin_app = axum::Router::new()
             .route(RELOAD_PATH, post(handle_reload))
-            .route(REVOKE_JWT, post(handle_revoke_jwt))
+            .route(REVOKE_MODULE_PATH, post(handle_revoke_module))
             .route_layer(middleware::from_fn_with_state(state.clone(), admin_auth))
             .with_state(state.clone())
             .route_layer(middleware::from_fn(log_request))
@@ -311,7 +311,7 @@ async fn handle_reload(
     Ok(StatusCode::OK)
 }
 
-async fn handle_revoke_jwt(
+async fn handle_revoke_module(
     State(state): State<SigningState>,
     Json(request): Json<RevokeJWTRequest>,
 ) -> Result<impl IntoResponse, SignerModuleError> {

--- a/docs/docs/get_started/configuration.md
+++ b/docs/docs/get_started/configuration.md
@@ -369,7 +369,7 @@ docker compose -f cb.docker-compose.yml exec cb_signer curl -X POST http://local
 
 The signer module takes 2 optional parameters in the JSON body:
 
-- `jwt_secrets`: a string with a comma-separated list of `<MODULE_ID>=JWT_SECRET` for all modules.
+- `jwt_secrets`: a string with a comma-separated list of `<MODULE_ID>=<JWT_SECRET>` for all modules.
 - `admin_secret`: a string with the secret for the signer admin JWT.
 
 In the case that someone of those isn't present, that parameter won't be updated.

--- a/docs/docs/get_started/configuration.md
+++ b/docs/docs/get_started/configuration.md
@@ -365,6 +365,15 @@ Commit-Boost supports hot-reloading the configuration file. This means that you 
 docker compose -f cb.docker-compose.yml exec cb_signer curl -X POST http://localhost:20000/reload
 ```
 
+### Signer module reload
+
+The signer module takes 2 optional parameters in the JSON body:
+
+- `jwt_secrets`: a string with a comma-separated list of `<MODULE_ID>=JWT_SECRET` for all modules.
+- `admin_secret`: a string with the secret for the signer admin JWT.
+
+In the case that someone of those isn't present, that parameter won't be updated.
+
 ### Notes
 
 - The hot reload feature is available for PBS modules (both default and custom) and signer module.

--- a/docs/docs/get_started/running/binary.md
+++ b/docs/docs/get_started/running/binary.md
@@ -27,6 +27,7 @@ Modules need some environment variables to work correctly.
 
 ### Signer Module
 - `CB_SIGNER_JWT_SECRET`: secret to use for JWT authentication with the Signer module.
+- `CB_SIGNER_ADMIN_JWT`: secret to use for admin JWT.
 - `CB_SIGNER_PORT`: required, port to open the signer server on.
 - For loading keys we currently support:
   - `CB_SIGNER_LOADER_FILE`: path to a `.json` with plaintext keys (for testing purposes only).


### PR DESCRIPTION
Now the `reload` endpoint on the signer module allows to update the JWT secrets too.
Also, a new `revoke_module` endpoint was added, to quickly remove the permissions for a compromised module.
This two endpoints are now under a new middleware that validates a special "admin" JWT, whose secret is autogenerated on the `init` command.