### PR TITLE
CBST2-08: Validate participant ID for Dirk signer

### DIFF
--- a/crates/signer/src/manager/dirk.rs
+++ b/crates/signer/src/manager/dirk.rs
@@ -660,7 +660,10 @@ fn load_distributed_accounts(
         };
 
         if participant_id == 0 {
-            warn!("Skiping invalid participant ID (0)");
+            warn!(
+                "Skiping invalid participant ID (0) for account {} in host {host_name}",
+                account.name
+            );
             continue
         }
 

--- a/crates/signer/src/manager/dirk.rs
+++ b/crates/signer/src/manager/dirk.rs
@@ -669,7 +669,12 @@ fn load_distributed_accounts(
 
         match consensus_accounts.get_mut(&public_key) {
             Some(Account::Distributed(DistributedAccount { participants, .. })) => {
-                participants.insert(participant_id as u32, channel.clone());
+                if participants.insert(participant_id as u32, channel.clone()).is_some() {
+                    warn!(
+                        "Duplicated participant ID ({participant_id}) for account {} in host {host_name}. Keeping this host",
+                        account.name
+                    );
+                }
             }
             None => {
                 let Ok((wallet, name)) = decompose_name(&account.name) else {

--- a/crates/signer/src/manager/dirk.rs
+++ b/crates/signer/src/manager/dirk.rs
@@ -659,6 +659,11 @@ fn load_distributed_accounts(
             continue;
         };
 
+        if participant_id == 0 {
+            warn!("Skiping invalid participant ID (0)");
+            continue
+        }
+
         match consensus_accounts.get_mut(&public_key) {
             Some(Account::Distributed(DistributedAccount { participants, .. })) => {
                 participants.insert(participant_id as u32, channel.clone());


### PR DESCRIPTION
If a Dirk host returns an account with participant ID 0 (which is invalid), it will be skipped for that account.