### PR TITLE
feat(signer): Request wallets instead of accounts in Dirk setup

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -171,13 +171,13 @@ url = "http://0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09f
 # server_name = "localhost-1"
 # Complete URL of a Dirk gateway
 # url = "https://localhost:8881"
-# Accounts to use as consensus keys
-# accounts = ["Wallet1/Account1", "DistributedWallet/Account1"]
+# Wallets to load consensus keys from
+# accounts = ["Wallet1", "DistributedWallet"]
 
 # [[signer.dirk.hosts]]
 # server_name = "localhost-2"
 # url = "https://localhost:8882"
-# accounts = ["Wallet2/Account2", "DistributedWallet/Account1"]
+# accounts = ["Wallet2", "DistributedWallet"]
 
 # Configuration for how the Signer module should store proxy delegations.
 # OPTIONAL

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -37,8 +37,8 @@ pub struct DirkHostConfig {
     pub server_name: Option<String>,
     /// Complete URL of the Dirk server
     pub url: Url,
-    /// Accounts used as consensus keys
-    pub accounts: Vec<String>,
+    /// Wallets to load consensus keys from
+    pub wallets: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/docs/docs/get_started/configuration.md
+++ b/docs/docs/get_started/configuration.md
@@ -256,16 +256,16 @@ ca_cert_path = "/path/to/ca.crt"
 [[signer.dirk.hosts]]
 server_name = "localhost-1"
 url = "https://localhost-1:8081"
-accounts = ["SomeWallet/SomeAccount", "DistributedWallet/Account1"]
+wallets = ["SomeWallet", "DistributedWallet"]
 
 [[signer.dirk.hosts]]
 server_name = "localhost-2"
 url = "https://localhost-2:8082"
-accounts = ["AnotherWallet/AnotherAccount", "DistributedWallet/Account1"]
+wallets = ["AnotherWallet", "DistributedWallet"]
 ```
 
 - `cert_path` and `key_path` are the paths to the client certificate and key used to authenticate with Dirk.
-- `accounts` is a list of accounts that the Signer module will consider as the consensus keys. Each account has the format `<WALLET_NAME>/<ACCOUNT>`. Accounts can be from different wallets. Generated proxy keys will have format `<WALLET_NAME>/<ACCOUNT>/<MODULE_ID>/<UUID>`.
+- `wallets` is a list of wallets from which the Signer module will load all accounts as consensus keys. Generated proxy keys will have format `<WALLET_NAME>/<ACCOUNT>/<MODULE_ID>/<UUID>`, so accounts found with that pattern will be ignored.
 - `secrets_path` is the path to the folder containing the passwords of the generated proxy accounts, which will be stored in `<secrets_path>/<WALLET_NAME>/<ACCOUNT>/<MODULE_ID>/<UUID>.pass`.
 
 Additionally, you can set a proxy store so that the delegation signatures for generated proxy keys are stored locally. As these signatures are not sensitive, the only supported store type is `File`:

--- a/examples/configs/dirk_signer.toml
+++ b/examples/configs/dirk_signer.toml
@@ -18,7 +18,7 @@ ca_cert_path = "/path/to/ca.crt"
 # Example of a single Dirk host
 [[signer.dirk.hosts]]
 url = "https://gateway.dirk.url"
-accounts = ["wallet1/accountX", "wallet2/accountY"]
+wallets = ["wallet1", "wallet2"]
 
 [signer.dirk.store]
 proxy_dir = "/path/to/proxies"


### PR DESCRIPTION
Some operators pointed that they have a lot of Dirk accounts and it's not easy to set them all in the config. With this changes they only need to set the wallets, and the signer will load all accounts found in those. Accounts with names that matches a proxy key name will be ignored.

Close #301 