### PR TITLE
CBST2-07: Add validation to the PBS config in the muxer

### DIFF
--- a/crates/common/src/config/mux.rs
+++ b/crates/common/src/config/mux.rs
@@ -89,6 +89,7 @@ impl PbsMuxes {
                     .unwrap_or(default_pbs.late_in_slot_time_ms),
                 ..default_pbs.clone()
             };
+            config.validate(chain).await?;
             let config = Arc::new(config);
 
             let runtime_config = RuntimeMuxConfig { id: mux.id, config, relays: relay_clients };


### PR DESCRIPTION
This resolves issue 07 by adding validation of the PBS config to the muxer as part of config loading.