### PR TITLE
CBST2-14: Rename proxy_pubkey for ECDSA proxies

### DIFF
--- a/crates/common/src/signer/store.rs
+++ b/crates/common/src/signer/store.rs
@@ -426,7 +426,7 @@ fn store_erc2335_key<T: ProxyId>(
     secrets_path: &Path,
     scheme: EncryptionScheme,
 ) -> eyre::Result<()> {
-    let proxy_pubkey = delegation.message.proxy;
+    let proxy_delegation = delegation.message.proxy;
 
     let password_bytes: [u8; 32] = rand::rng().random();
     let password = hex::encode(password_bytes);
@@ -436,7 +436,7 @@ fn store_erc2335_key<T: ProxyId>(
         .join(&module_id.0)
         .join(scheme.to_string());
     std::fs::create_dir_all(&pass_path)?;
-    let pass_path = pass_path.join(proxy_pubkey.to_string());
+    let pass_path = pass_path.join(proxy_delegation.to_string());
     let mut pass_file = std::fs::File::create(&pass_path)?;
     pass_file.write_all(password.as_bytes())?;
 
@@ -445,7 +445,7 @@ fn store_erc2335_key<T: ProxyId>(
         .join(&module_id.0)
         .join(scheme.to_string());
     std::fs::create_dir_all(&sig_path)?;
-    let sig_path = sig_path.join(format!("{}.sig", proxy_pubkey));
+    let sig_path = sig_path.join(format!("{}.sig", proxy_delegation));
 
     let mut sig_file = std::fs::File::create(sig_path)?;
     sig_file.write_all(delegation.signature.to_string().as_bytes())?;
@@ -489,7 +489,7 @@ fn store_erc2335_key<T: ProxyId>(
         .join(&module_id.0)
         .join(scheme.to_string());
     std::fs::create_dir_all(&json_path)?;
-    let json_path = json_path.join(format!("{}.json", proxy_pubkey));
+    let json_path = json_path.join(format!("{}.json", proxy_delegation));
     let mut json_file = std::fs::File::create(&json_path)?;
     json_file.write_all(serde_json::to_string(&keystore)?.as_bytes())?;
 

--- a/crates/signer/src/manager/local.rs
+++ b/crates/signer/src/manager/local.rs
@@ -79,9 +79,9 @@ impl LocalSigningManager {
             store.store_proxy_ecdsa(&module_id, &proxy)?;
         }
 
-        let proxy_pubkey = proxy.address();
+        let proxy_address = proxy.address();
         self.proxy_signers.ecdsa_signers.insert(proxy.address(), proxy);
-        self.proxy_addresses_ecdsa.entry(module_id).or_default().push(proxy_pubkey);
+        self.proxy_addresses_ecdsa.entry(module_id).or_default().push(proxy_address);
 
         Ok(())
     }
@@ -111,9 +111,9 @@ impl LocalSigningManager {
         delegator: BlsPublicKey,
     ) -> Result<SignedProxyDelegationEcdsa, SignerModuleError> {
         let signer = EcdsaSigner::new_random();
-        let proxy_pubkey = signer.address();
+        let proxy_address = signer.address();
 
-        let message = ProxyDelegationEcdsa { delegator, proxy: proxy_pubkey };
+        let message = ProxyDelegationEcdsa { delegator, proxy: proxy_address };
         let signature = self.sign_consensus(&delegator, &message.tree_hash_root().0).await?;
         let delegation = SignedProxyDelegationEcdsa { signature, message };
         let proxy_signer = EcdsaProxySigner { signer, delegation };

--- a/docs/docs/developing/commit-module.md
+++ b/docs/docs/developing/commit-module.md
@@ -88,18 +88,21 @@ let proxy_pubkey = proxy_delegation.message.proxy;
 
 // or ECDSA proxy
 let proxy_delegation = self.config.signer_client.generate_proxy_key_ecdsa(pubkey).await?;
-let proxy_pubkey = proxy_delegation.message.proxy;
+let proxy_address = proxy_delegation.message.proxy;
 ```
 
 Where `pubkey` is the validator (consensus) public key for which a proxy is to be generated.
 
 Then you can use the generated proxy key to request a signature:
 ```rust
+// if `proxy_pubkey` is a BLS proxy
 let datagram = Datagram { data: 1 };
 let request = SignProxyRequest::builder(proxy_pubkey).with_msg(&datagram);
-// if `proxy_pubkey` is a BLS proxy
 let signature = config.signer_client.request_proxy_signature_bls(&request).await.unwrap();
+
 // or for ECDSA proxy
+let datagram = Datagram { data: 1 };
+let request = SignProxyRequest::builder(proxy_address).with_msg(&datagram);
 let signature = config.signer_client.request_proxy_signature_ecdsa(&request).await.unwrap();
 ```
 


### PR DESCRIPTION
This renames the `proxy_pubkey` variable in ECDSA or mixed contexts, since ECDSA addresses are not pubkeys.