### PR TITLE
Add retry limit for validator registration (#316)

### DIFF
--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -27,11 +27,11 @@ use crate::{
     },
     pbs::{
         BuilderEventPublisher, DefaultTimeout, RelayClient, RelayEntry, DEFAULT_PBS_PORT,
-        LATE_IN_SLOT_TIME_MS,
+        LATE_IN_SLOT_TIME_MS, REGISTER_VALIDATOR_RETRY_LIMIT
     },
     types::{Chain, Jwt, ModuleId},
     utils::{
-        as_eth_str, default_bool, default_host, default_u16, default_u256, default_u64, WEI_PER_ETH,
+        as_eth_str, default_bool, default_host, default_u16, default_u256, default_u64, default_u32, WEI_PER_ETH,
     },
 };
 
@@ -122,6 +122,9 @@ pub struct PbsConfig {
     pub extra_validation_enabled: bool,
     /// Execution Layer RPC url to use for extra validation
     pub rpc_url: Option<Url>,
+    /// Maximum number of retries for validator registration request per relay
+    #[serde(default = "default_u32::<REGISTER_VALIDATOR_RETRY_LIMIT>")]
+    pub register_validator_retry_limit: u32,
 }
 
 impl PbsConfig {
@@ -140,6 +143,7 @@ impl PbsConfig {
             self.timeout_get_header_ms < self.late_in_slot_time_ms,
             "timeout_get_header_ms must be less than late_in_slot_time_ms"
         );
+        ensure!(self.register_validator_retry_limit > 0,"register_validator_retry_limit must be greater than 0");
 
         ensure!(
             self.min_bid_wei < U256::from(WEI_PER_ETH),

--- a/crates/common/src/pbs/constants.rs
+++ b/crates/common/src/pbs/constants.rs
@@ -30,3 +30,6 @@ impl DefaultTimeout {
 }
 
 pub const LATE_IN_SLOT_TIME_MS: u64 = 2000;
+
+// Maximum number of retries for validator registration request per relay
+pub const REGISTER_VALIDATOR_RETRY_LIMIT: u32 = 3;

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -137,6 +137,10 @@ pub const fn default_u64<const U: u64>() -> u64 {
     U
 }
 
+pub const fn default_u32<const U: u32>() -> u32 {
+    U
+}
+
 pub const fn default_u16<const U: u16>() -> u16 {
     U
 }

--- a/crates/pbs/src/mev_boost/register_validator.rs
+++ b/crates/pbs/src/mev_boost/register_validator.rs
@@ -43,6 +43,7 @@ pub async fn register_validator<S: BuilderApiState>(
                         relay.clone(),
                         send_headers.clone(),
                         state.pbs_config().timeout_register_validator_ms,
+                        state.pbs_config().register_validator_retry_limit,
                     )
                     .in_current_span(),
                 ));
@@ -54,6 +55,7 @@ pub async fn register_validator<S: BuilderApiState>(
                     relay.clone(),
                     send_headers.clone(),
                     state.pbs_config().timeout_register_validator_ms,
+                    state.pbs_config().register_validator_retry_limit,
                 )
                 .in_current_span(),
             ));
@@ -85,6 +87,7 @@ async fn send_register_validator_with_timeout(
     relay: RelayClient,
     headers: HeaderMap,
     timeout_ms: u64,
+    retry_limit: u32,
 ) -> Result<(), PbsError> {
     let url = relay.register_validator_url()?;
     let mut remaining_timeout_ms = timeout_ms;
@@ -106,6 +109,14 @@ async fn send_register_validator_with_timeout(
             Ok(_) => return Ok(()),
 
             Err(err) if err.should_retry() => {
+                if retry >=retry_limit {
+                    error!(
+                        relay_id = relay.id.as_str(),
+                        retry,
+                        "reached retry limit for validator registration"
+                    );
+                    return Err(err);
+                }
                 tokio::time::sleep(backoff).await;
                 backoff += Duration::from_millis(250);
 


### PR DESCRIPTION
## 📝 Description
This PR resolves #316 by introducing a configurable retry limit for validator registration requests. The goal is to prevent unnecessary network traffic, reduce load on relays, and avoid log clutter caused by excessive retries on client-side errors (e.g., 400, 429).

## 💡 Motivation and Context
if a relay responded with errors like 400 (unknown validator) or 429 (too many requests), client would keep retrying continously. This PR adds a limit to those retries to avoid putting unnecessary load on relays and to keep the logs clean.

## What is Included

- Introduced `register_validator_retry_limit` to PbsConfig (default = 3)
- Used this field in `send_register_validator_with_timeout` to cap total attempts
- Updated retry logic to perform: `max retry < retry_limit`
- Ensured retry count is passed and logged in each attempt
- Maintained existing structure and logging patterns

## Behavior
- With `register_validator_retry_limit` = 3:
- Total of 3 request attempts allowed: `retry = 0, 1, 2`
- On retry = 3, aborts with logged error

Issue
Closes #316