### PR TITLE
fix(doc): add max retries to example config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -49,7 +49,7 @@ min_bid_eth = 0.0
 # to force local building and miniminzing the risk of missed slots. See also the timing games section below
 # OPTIONAL, DEFAULT: 2000
 late_in_slot_time_ms = 2000
-# Whether to enable extra validation of get_header responses, if this is enabled you need to set `rpc_url`
+# Whether to enable extra validation of get_header responses, if this is enabled `rpc_url` must also be set
 # OPTIONAL, DEFAULT: false
 extra_validation_enabled = false
 # Execution Layer RPC url to use for extra validation
@@ -117,18 +117,20 @@ validator_pubkeys = [
     "0x80c7f782b2467c5898c5516a8b6595d75623960b4afc4f71ee07d40985d20e117ba35e7cd352a3e75fb85a8668a3b745",
     "0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09fe73ccd21f88eab31d6de16194d17782e",
 ]
-# Path to a file containing a list of validator pubkeys or details of a registry to load keys from.
-# Supported registries:
-#   - Lido: NodeOperatorsRegistry
-#   - SSV: SSV API
-# OPTIONAL
-loader = "./tests/data/mux_keys.example.json"
-# URL to HTTP endpoint returning JSON list of validator pubkeys
-# Example response:
+# Loader for validator pubkeys. Three types of loaders are supported:
+#   - File: path to a file containing a list of validator pubkeys in JSON format
+#   - URL: URL to an HTTP endpoint returning a list of validator pubkeys in JSON format
+#   - Registry: details of a registry to load keys from. Supported registries:
+#       - Lido: NodeOperatorsRegistry
+#       - SSV: SSV API
+#
+# Example JSON list:
 # [
 #   "0x80c7f782b2467c5898c5516a8b6595d75623960b4afc4f71ee07d40985d20e117ba35e7cd352a3e75fb85a8668a3b745",
 #   "0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09fe73ccd21f88eab31d6de16194d17782e"
 #]
+# OPTIONAL
+loader = "./tests/data/mux_keys.example.json"
 # loader = { url = "http://localhost:8000/keys" }
 # loader = { registry = "lido", node_operator_id = 8 }
 # loader = { registry = "ssv", node_operator_id = 8 }


### PR DESCRIPTION
#322 introduced a new config param for limiting the max number of registrations retries. This PR adds that param to the example config + some tidy up