### PR TITLE
Allow empty relays list in the config

### DIFF
--- a/crates/common/src/config/mod.rs
+++ b/crates/common/src/config/mod.rs
@@ -26,6 +26,7 @@ pub use utils::*;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CommitBoostConfig {
     pub chain: Chain,
+    #[serde(default)]
     pub relays: Vec<RelayConfig>,
     pub pbs: StaticPbsConfig,
     #[serde(flatten)]

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -229,6 +229,14 @@ pub async fn load_pbs_config() -> Result<PbsModuleConfig> {
     let config = CommitBoostConfig::from_env_path()?;
     config.validate().await?;
 
+    // Make sure relays isn't empty - since the config is still technically valid if
+    // there are no relays for things like Docker compose generation, this check
+    // isn't in validate().
+    ensure!(
+        !config.relays.is_empty(),
+        "At least one relay must be configured to run the PBS service"
+    );
+
     // use endpoint from env if set, otherwise use default host and port
     let endpoint = if let Some(endpoint) = load_optional_env_var(PBS_ENDPOINT_ENV) {
         endpoint.parse()?

--- a/tests/tests/config.rs
+++ b/tests/tests/config.rs
@@ -170,3 +170,15 @@ async fn test_validate_missing_rpc_url() -> Result<()> {
         .contains("rpc_url is required if extra_validation_enabled is true"));
     Ok(())
 }
+
+#[tokio::test]
+async fn test_validate_config_with_no_relays() -> Result<()> {
+    // Create a config with no relays
+    let mut config = load_happy_config().await?;
+    config.relays.clear();
+
+    // Make sure it validates correctly
+    let result = config.validate().await;
+    assert!(result.is_ok());
+    Ok(())
+}


### PR DESCRIPTION
This PR allows the config to have an empty / non-present `[[relays]]` list for situations where starting PBS isn't needed, such as generating the Docker compose file with the CLI's `init` action. Down the line when a config can be created for just the signer without PBS, this will be important as well. Ensuring the relay list has at least one entry is now done in `load_pbs_config()`, which is part of starting the actual PBS service.