### PR TITLE
&expected_relay_pubkey

### DIFF
--- a/crates/pbs/src/mev_boost/get_header.rs
+++ b/crates/pbs/src/mev_boost/get_header.rs
@@ -470,7 +470,7 @@ fn validate_signature<T: TreeHash>(
 
     verify_signed_message(
         chain,
-        &received_relay_pubkey,
+        &expected_relay_pubkey,,
         &message,
         signature,
         APPLICATION_BUILDER_DOMAIN,


### PR DESCRIPTION
check against the static pubkey, not the pubkey in the message