### PR TITLE
Chore: cleanup some signer consts

### DIFF
--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -15,10 +15,10 @@ use cb_common::{
         PROXY_DIR_KEYS_ENV, PROXY_DIR_SECRETS_DEFAULT, PROXY_DIR_SECRETS_ENV, SIGNER_DEFAULT,
         SIGNER_DIR_KEYS_DEFAULT, SIGNER_DIR_KEYS_ENV, SIGNER_DIR_SECRETS_DEFAULT,
         SIGNER_DIR_SECRETS_ENV, SIGNER_ENDPOINT_ENV, SIGNER_KEYS_ENV, SIGNER_MODULE_NAME,
-        SIGNER_URL_ENV,
+        SIGNER_PORT_DEFAULT, SIGNER_URL_ENV,
     },
     pbs::{BUILDER_API_PATH, GET_STATUS_PATH},
-    signer::{ProxyStore, SignerLoader, DEFAULT_SIGNER_PORT},
+    signer::{ProxyStore, SignerLoader},
     types::ModuleId,
     utils::random_jwt_secret,
 };
@@ -73,7 +73,7 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
     let mut targets = Vec::new();
 
     // address for signer API communication
-    let signer_port = cb_config.signer.as_ref().map(|s| s.port).unwrap_or(DEFAULT_SIGNER_PORT);
+    let signer_port = cb_config.signer.as_ref().map(|s| s.port).unwrap_or(SIGNER_PORT_DEFAULT);
     let signer_server =
         if let Some(SignerConfig { inner: SignerType::Remote { url }, .. }) = &cb_config.signer {
             url.to_string()

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -34,11 +34,16 @@ pub const SIGNER_MODULE_NAME: &str = "signer";
 
 /// Where the signer module should open the server
 pub const SIGNER_ENDPOINT_ENV: &str = "CB_SIGNER_ENDPOINT";
+pub const SIGNER_PORT_DEFAULT: u16 = 20000;
 
-// JWT authentication settings
+/// Number of auth failures before rate limiting the client
 pub const SIGNER_JWT_AUTH_FAIL_LIMIT_ENV: &str = "CB_SIGNER_JWT_AUTH_FAIL_LIMIT";
+pub const SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT: u32 = 3;
+
+/// How long to rate limit the client after auth failures
 pub const SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_ENV: &str =
     "CB_SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS";
+pub const SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT: u32 = 5 * 60;
 
 /// Comma separated list module_id=jwt_secret
 pub const JWTS_ENV: &str = "CB_JWTS";

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -12,15 +12,13 @@ use url::Url;
 
 use super::{
     load_jwt_secrets, load_optional_env_var, utils::load_env_var, CommitBoostConfig,
-    SIGNER_ENDPOINT_ENV, SIGNER_IMAGE_DEFAULT, SIGNER_JWT_AUTH_FAIL_LIMIT_ENV,
-    SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_ENV,
+    SIGNER_ENDPOINT_ENV, SIGNER_IMAGE_DEFAULT, SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT,
+    SIGNER_JWT_AUTH_FAIL_LIMIT_ENV, SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT,
+    SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_ENV, SIGNER_PORT_DEFAULT,
 };
 use crate::{
     config::{DIRK_CA_CERT_ENV, DIRK_CERT_ENV, DIRK_DIR_SECRETS_ENV, DIRK_KEY_ENV},
-    signer::{
-        ProxyStore, SignerLoader, DEFAULT_JWT_AUTH_FAIL_LIMIT,
-        DEFAULT_JWT_AUTH_FAIL_TIMEOUT_SECONDS, DEFAULT_SIGNER_PORT,
-    },
+    signer::{ProxyStore, SignerLoader},
     types::{Chain, ModuleId},
     utils::{default_host, default_u16, default_u32},
 };
@@ -32,20 +30,20 @@ pub struct SignerConfig {
     #[serde(default = "default_host")]
     pub host: Ipv4Addr,
     /// Port to listen for signer API calls on
-    #[serde(default = "default_u16::<DEFAULT_SIGNER_PORT>")]
+    #[serde(default = "default_u16::<SIGNER_PORT_DEFAULT>")]
     pub port: u16,
     /// Docker image of the module
-    #[serde(default = "default_signer")]
+    #[serde(default = "default_signer_image")]
     pub docker_image: String,
 
     /// Number of JWT auth failures before rate limiting an endpoint
     /// If set to 0, no rate limiting will be applied
-    #[serde(default = "default_u32::<DEFAULT_JWT_AUTH_FAIL_LIMIT>")]
+    #[serde(default = "default_u32::<SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT>")]
     pub jwt_auth_fail_limit: u32,
 
     /// Duration in seconds to rate limit an endpoint after the JWT auth failure
     /// limit has been reached
-    #[serde(default = "default_u32::<DEFAULT_JWT_AUTH_FAIL_TIMEOUT_SECONDS>")]
+    #[serde(default = "default_u32::<SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT>")]
     pub jwt_auth_fail_timeout_seconds: u32,
 
     /// Inner type-specific configuration
@@ -70,7 +68,7 @@ impl SignerConfig {
     }
 }
 
-fn default_signer() -> String {
+fn default_signer_image() -> String {
     SIGNER_IMAGE_DEFAULT.to_string()
 }
 

--- a/crates/common/src/signer/constants.rs
+++ b/crates/common/src/signer/constants.rs
@@ -1,6 +1,0 @@
-pub const DEFAULT_SIGNER_PORT: u16 = 20000;
-
-// Rate limit signer API requests for 5 minutes after the endpoint has 3 JWT
-// auth failures
-pub const DEFAULT_JWT_AUTH_FAIL_LIMIT: u32 = 3;
-pub const DEFAULT_JWT_AUTH_FAIL_TIMEOUT_SECONDS: u32 = 5 * 60;

--- a/crates/common/src/signer/mod.rs
+++ b/crates/common/src/signer/mod.rs
@@ -1,10 +1,8 @@
-mod constants;
 mod loader;
 mod schemes;
 mod store;
 mod types;
 
-pub use constants::*;
 pub use loader::*;
 pub use schemes::*;
 pub use store::*;

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -8,13 +8,11 @@ use alloy::{primitives::U256, rpc::types::beacon::BlsPublicKey};
 use cb_common::{
     config::{
         PbsConfig, PbsModuleConfig, RelayConfig, SignerConfig, SignerType, StartSignerConfig,
-        SIGNER_IMAGE_DEFAULT,
+        SIGNER_IMAGE_DEFAULT, SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT,
+        SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT, SIGNER_PORT_DEFAULT,
     },
     pbs::{RelayClient, RelayEntry},
-    signer::{
-        SignerLoader, DEFAULT_JWT_AUTH_FAIL_LIMIT, DEFAULT_JWT_AUTH_FAIL_TIMEOUT_SECONDS,
-        DEFAULT_SIGNER_PORT,
-    },
+    signer::SignerLoader,
     types::{Chain, ModuleId},
     utils::default_host,
 };
@@ -106,10 +104,10 @@ pub fn to_pbs_config(
 pub fn get_signer_config(loader: SignerLoader) -> SignerConfig {
     SignerConfig {
         host: default_host(),
-        port: DEFAULT_SIGNER_PORT,
+        port: SIGNER_PORT_DEFAULT,
         docker_image: SIGNER_IMAGE_DEFAULT.to_string(),
-        jwt_auth_fail_limit: DEFAULT_JWT_AUTH_FAIL_LIMIT,
-        jwt_auth_fail_timeout_seconds: DEFAULT_JWT_AUTH_FAIL_TIMEOUT_SECONDS,
+        jwt_auth_fail_limit: SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT,
+        jwt_auth_fail_timeout_seconds: SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT,
         inner: SignerType::Local { loader, store: None },
     }
 }


### PR DESCRIPTION
This was supposed to be part of #310 but didn't make it in before the PR was merged. It instead went into #329, but I'm moving it into its own PR for cleanliness.

All this does is some slight refactoring of a few Signer constants, moving them to a better home and standardizing their names.