### PR TITLE
Add blinded blocks v2

### DIFF
--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -17,7 +17,7 @@ use cb_common::{
         SIGNER_DIR_SECRETS_ENV, SIGNER_ENDPOINT_ENV, SIGNER_KEYS_ENV, SIGNER_MODULE_NAME,
         SIGNER_URL_ENV,
     },
-    pbs::{BUILDER_API_PATH, GET_STATUS_PATH},
+    pbs::{BUILDER_V1_API_PATH, GET_STATUS_PATH},
     signer::{ProxyStore, SignerLoader, DEFAULT_SIGNER_PORT},
     types::ModuleId,
     utils::random_jwt_secret,
@@ -308,7 +308,7 @@ pub async fn handle_docker_init(config_path: PathBuf, output_dir: PathBuf) -> Re
         healthcheck: Some(Healthcheck {
             test: Some(HealthcheckTest::Single(format!(
                 "curl -f http://localhost:{}{}{}",
-                cb_config.pbs.pbs_config.port, BUILDER_API_PATH, GET_STATUS_PATH
+                cb_config.pbs.pbs_config.port, BUILDER_V1_API_PATH, GET_STATUS_PATH
             ))),
             interval: Some("30s".into()),
             timeout: Some("5s".into()),

--- a/crates/common/src/pbs/builder.rs
+++ b/crates/common/src/pbs/builder.rs
@@ -1,0 +1,30 @@
+use std::fmt::{Display, Formatter, Result};
+
+use serde::{Deserialize, Serialize};
+
+use crate::pbs::{BUILDER_V1_API_PATH, BUILDER_V2_API_PATH};
+
+// Version of the builder API for various routes
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BuilderApiVersion {
+    V1 = 1,
+    V2,
+}
+impl BuilderApiVersion {
+    pub const fn path(&self) -> &'static str {
+        match self {
+            BuilderApiVersion::V1 => BUILDER_V1_API_PATH,
+            BuilderApiVersion::V2 => BUILDER_V2_API_PATH,
+        }
+    }
+}
+impl Display for BuilderApiVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let s = match self {
+            BuilderApiVersion::V1 => "v1",
+            BuilderApiVersion::V2 => "v2",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/crates/common/src/pbs/constants.rs
+++ b/crates/common/src/pbs/constants.rs
@@ -1,6 +1,7 @@
 use crate::constants::COMMIT_BOOST_VERSION;
 
-pub const BUILDER_API_PATH: &str = "/eth/v1/builder";
+pub const BUILDER_V1_API_PATH: &str = "/eth/v1/builder";
+pub const BUILDER_V2_API_PATH: &str = "/eth/v2/builder";
 
 pub const GET_HEADER_PATH: &str = "/header/{slot}/{parent_hash}/{pubkey}";
 pub const GET_STATUS_PATH: &str = "/status";

--- a/crates/common/src/pbs/event.rs
+++ b/crates/common/src/pbs/event.rs
@@ -30,7 +30,8 @@ pub enum BuilderEvent {
     GetStatusEvent,
     GetStatusResponse,
     SubmitBlockRequest(Box<SignedBlindedBeaconBlock>, BuilderApiVersion),
-    SubmitBlockResponse(Box<SubmitBlindedBlockResponse>, BuilderApiVersion),
+    SubmitBlockResponseV1(Box<SubmitBlindedBlockResponse>),
+    SubmitBlockResponseV2,
     MissedPayload {
         /// Hash for the block for which no payload was received
         block_hash: B256,

--- a/crates/common/src/pbs/event.rs
+++ b/crates/common/src/pbs/event.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::{
     config::{load_optional_env_var, BUILDER_URLS_ENV, HTTP_TIMEOUT_SECONDS_DEFAULT},
-    pbs::BUILDER_EVENTS_PATH,
+    pbs::{BuilderApiVersion, BUILDER_EVENTS_PATH},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,8 +29,8 @@ pub enum BuilderEvent {
     GetHeaderResponse(Box<Option<GetHeaderResponse>>),
     GetStatusEvent,
     GetStatusResponse,
-    SubmitBlockRequest(Box<SignedBlindedBeaconBlock>),
-    SubmitBlockResponse(Box<SubmitBlindedBlockResponse>),
+    SubmitBlockRequest(Box<SignedBlindedBeaconBlock>, BuilderApiVersion),
+    SubmitBlockResponse(Box<SubmitBlindedBlockResponse>, BuilderApiVersion),
     MissedPayload {
         /// Hash for the block for which no payload was received
         block_hash: B256,

--- a/crates/common/src/pbs/mod.rs
+++ b/crates/common/src/pbs/mod.rs
@@ -1,9 +1,11 @@
+mod builder;
 mod constants;
 pub mod error;
 mod event;
 mod relay;
 mod types;
 
+pub use builder::*;
 pub use constants::*;
 pub use event::*;
 pub use relay::*;

--- a/crates/common/src/pbs/relay.rs
+++ b/crates/common/src/pbs/relay.rs
@@ -10,11 +10,11 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use super::{
-    constants::{BUILDER_API_PATH, GET_STATUS_PATH, REGISTER_VALIDATOR_PATH, SUBMIT_BLOCK_PATH},
+    constants::{GET_STATUS_PATH, REGISTER_VALIDATOR_PATH, SUBMIT_BLOCK_PATH},
     error::PbsError,
     HEADER_VERSION_KEY, HEADER_VERSION_VALUE,
 };
-use crate::{config::RelayConfig, DEFAULT_REQUEST_TIMEOUT};
+use crate::{config::RelayConfig, pbs::BuilderApiVersion, DEFAULT_REQUEST_TIMEOUT};
 
 /// A parsed entry of the relay url in the format: scheme://pubkey@host
 #[derive(Debug, Clone)]
@@ -101,8 +101,12 @@ impl RelayClient {
 
         Ok(url)
     }
-    pub fn builder_api_url(&self, path: &str) -> Result<Url, PbsError> {
-        self.get_url(&format!("{BUILDER_API_PATH}{path}"))
+    pub fn builder_api_url(
+        &self,
+        path: &str,
+        api_version: BuilderApiVersion,
+    ) -> Result<Url, PbsError> {
+        self.get_url(&format!("{}{path}", api_version.path()))
     }
 
     pub fn get_header_url(
@@ -111,19 +115,22 @@ impl RelayClient {
         parent_hash: B256,
         validator_pubkey: BlsPublicKey,
     ) -> Result<Url, PbsError> {
-        self.builder_api_url(&format!("/header/{slot}/{parent_hash}/{validator_pubkey}"))
+        self.builder_api_url(
+            &format!("/header/{slot}/{parent_hash}/{validator_pubkey}"),
+            BuilderApiVersion::V1,
+        )
     }
 
     pub fn get_status_url(&self) -> Result<Url, PbsError> {
-        self.builder_api_url(GET_STATUS_PATH)
+        self.builder_api_url(GET_STATUS_PATH, BuilderApiVersion::V1)
     }
 
     pub fn register_validator_url(&self) -> Result<Url, PbsError> {
-        self.builder_api_url(REGISTER_VALIDATOR_PATH)
+        self.builder_api_url(REGISTER_VALIDATOR_PATH, BuilderApiVersion::V1)
     }
 
-    pub fn submit_block_url(&self) -> Result<Url, PbsError> {
-        self.builder_api_url(SUBMIT_BLOCK_PATH)
+    pub fn submit_block_url(&self, api_version: BuilderApiVersion) -> Result<Url, PbsError> {
+        self.builder_api_url(SUBMIT_BLOCK_PATH, api_version)
     }
 }
 

--- a/crates/common/src/pbs/types/beacon_block.rs
+++ b/crates/common/src/pbs/types/beacon_block.rs
@@ -99,7 +99,7 @@ mod tests {
     // this is from mev-boost test data
     fn test_signed_blinded_block_fb_electra() {
         let data = include_str!("testdata/signed-blinded-beacon-block-electra.json");
-        let block = test_encode_decode::<SignedBlindedBeaconBlock>(&data);
+        let block = test_encode_decode::<SignedBlindedBeaconBlock>(data);
         assert!(matches!(block.message, BlindedBeaconBlock::Electra(_)));
     }
 
@@ -166,7 +166,7 @@ mod tests {
     // this is dummy data generated with https://github.com/attestantio/go-eth2-client
     fn test_signed_blinded_block_ssz() {
         let data_json = include_str!("testdata/signed-blinded-beacon-block-electra-2.json");
-        let block_json = test_encode_decode::<SignedBlindedBeaconBlock>(&data_json);
+        let block_json = test_encode_decode::<SignedBlindedBeaconBlock>(data_json);
         assert!(matches!(block_json.message, BlindedBeaconBlock::Electra(_)));
 
         let data_ssz = include_bytes!("testdata/signed-blinded-beacon-block-electra-2.ssz");
@@ -181,7 +181,7 @@ mod tests {
     // this is dummy data generated with https://github.com/attestantio/go-builder-client
     fn test_execution_payload_block_ssz() {
         let data_json = include_str!("testdata/execution-payload-electra.json");
-        let block_json = test_encode_decode::<PayloadAndBlobsElectra>(&data_json);
+        let block_json = test_encode_decode::<PayloadAndBlobsElectra>(data_json);
 
         let data_ssz = include_bytes!("testdata/execution-payload-electra.ssz");
         let data_ssz = alloy::primitives::hex::decode(data_ssz).unwrap();

--- a/crates/common/src/pbs/types/execution_payload.rs
+++ b/crates/common/src/pbs/types/execution_payload.rs
@@ -129,7 +129,7 @@ mod tests {
             "excess_blob_gas": "95158272"
         }"#;
 
-        let parsed = test_encode_decode::<ExecutionPayloadHeader<ElectraSpec>>(&data);
+        let parsed = test_encode_decode::<ExecutionPayloadHeader<ElectraSpec>>(data);
 
         assert_eq!(
             parsed.parent_hash,

--- a/crates/common/src/pbs/types/get_header.rs
+++ b/crates/common/src/pbs/types/get_header.rs
@@ -166,7 +166,7 @@ mod tests {
             }
         }"#;
 
-        let parsed = test_encode_decode::<GetHeaderResponse>(&data);
+        let parsed = test_encode_decode::<GetHeaderResponse>(data);
         let VersionedResponse::Electra(parsed) = parsed;
 
         assert_eq!(parsed.message.value, U256::from(1));
@@ -187,7 +187,7 @@ mod tests {
         let data_json = include_str!("testdata/get-header-response.json");
         let block_json = test_encode_decode::<
             SignedExecutionPayloadHeader<ExecutionPayloadHeaderMessageElectra>,
-        >(&data_json);
+        >(data_json);
 
         let data_ssz = include_bytes!("testdata/get-header-response.ssz");
         let data_ssz = alloy::primitives::hex::decode(data_ssz).unwrap();

--- a/crates/pbs/src/api.rs
+++ b/crates/pbs/src/api.rs
@@ -39,7 +39,7 @@ pub trait BuilderApi<S: BuilderApiState>: 'static {
         req_headers: HeaderMap,
         state: PbsState<S>,
         api_version: &BuilderApiVersion,
-    ) -> eyre::Result<SubmitBlindedBlockResponse> {
+    ) -> eyre::Result<Option<SubmitBlindedBlockResponse>> {
         mev_boost::submit_block(signed_blinded_block, req_headers, state, api_version).await
     }
 

--- a/crates/pbs/src/api.rs
+++ b/crates/pbs/src/api.rs
@@ -2,7 +2,8 @@ use alloy::rpc::types::beacon::relay::ValidatorRegistration;
 use async_trait::async_trait;
 use axum::{http::HeaderMap, Router};
 use cb_common::pbs::{
-    GetHeaderParams, GetHeaderResponse, SignedBlindedBeaconBlock, SubmitBlindedBlockResponse,
+    BuilderApiVersion, GetHeaderParams, GetHeaderResponse, SignedBlindedBeaconBlock,
+    SubmitBlindedBlockResponse,
 };
 
 use crate::{
@@ -31,13 +32,15 @@ pub trait BuilderApi<S: BuilderApiState>: 'static {
         mev_boost::get_status(req_headers, state).await
     }
 
-    /// https://ethereum.github.io/builder-specs/#/Builder/submitBlindedBlock
+    /// https://ethereum.github.io/builder-specs/#/Builder/submitBlindedBlock and
+    /// https://ethereum.github.io/builder-specs/#/Builder/submitBlindedBlockV2
     async fn submit_block(
         signed_blinded_block: SignedBlindedBeaconBlock,
         req_headers: HeaderMap,
         state: PbsState<S>,
+        api_version: &BuilderApiVersion,
     ) -> eyre::Result<SubmitBlindedBlockResponse> {
-        mev_boost::submit_block(signed_blinded_block, req_headers, state).await
+        mev_boost::submit_block(signed_blinded_block, req_headers, state, api_version).await
     }
 
     /// https://ethereum.github.io/builder-specs/#/Builder/registerValidator

--- a/crates/pbs/src/routes/mod.rs
+++ b/crates/pbs/src/routes/mod.rs
@@ -9,4 +9,4 @@ use get_header::handle_get_header;
 use register_validator::handle_register_validator;
 pub use router::create_app_router;
 use status::handle_get_status;
-use submit_block::handle_submit_block;
+use submit_block::handle_submit_block_v1;

--- a/crates/pbs/src/service.rs
+++ b/crates/pbs/src/service.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use cb_common::{
     constants::{COMMIT_BOOST_COMMIT, COMMIT_BOOST_VERSION},
-    pbs::{BUILDER_API_PATH, GET_STATUS_PATH},
+    pbs::{BUILDER_V1_API_PATH, GET_STATUS_PATH},
     types::Chain,
 };
 use cb_metrics::provider::MetricsProvider;
@@ -40,7 +40,7 @@ impl PbsService {
         // wait for the server to start
         tokio::time::sleep(Duration::from_millis(250)).await;
         let local_url =
-            Url::parse(&format!("http://{}{}{}", addr, BUILDER_API_PATH, GET_STATUS_PATH))?;
+            Url::parse(&format!("http://{}{}{}", addr, BUILDER_V1_API_PATH, GET_STATUS_PATH))?;
 
         let status = reqwest::get(local_url).await?;
         if !status.status().is_success() {

--- a/tests/src/mock_validator.rs
+++ b/tests/src/mock_validator.rs
@@ -2,7 +2,7 @@ use alloy::{
     primitives::B256,
     rpc::types::beacon::{relay::ValidatorRegistration, BlsPublicKey},
 };
-use cb_common::pbs::{RelayClient, SignedBlindedBeaconBlock};
+use cb_common::pbs::{BuilderApiVersion, RelayClient, SignedBlindedBeaconBlock};
 use reqwest::Response;
 
 use crate::utils::generate_mock_relay;
@@ -39,11 +39,26 @@ impl MockValidator {
         Ok(self.comm_boost.client.post(url).json(&registrations).send().await?)
     }
 
-    pub async fn do_submit_block(
+    pub async fn do_submit_block_v1(
         &self,
         signed_blinded_block: Option<SignedBlindedBeaconBlock>,
     ) -> eyre::Result<Response> {
-        let url = self.comm_boost.submit_block_url().unwrap();
+        self.do_submit_block_impl(signed_blinded_block, BuilderApiVersion::V1).await
+    }
+
+    pub async fn do_submit_block_v2(
+        &self,
+        signed_blinded_block: Option<SignedBlindedBeaconBlock>,
+    ) -> eyre::Result<Response> {
+        self.do_submit_block_impl(signed_blinded_block, BuilderApiVersion::V2).await
+    }
+
+    async fn do_submit_block_impl(
+        &self,
+        signed_blinded_block: Option<SignedBlindedBeaconBlock>,
+        api_version: BuilderApiVersion,
+    ) -> eyre::Result<Response> {
+        let url = self.comm_boost.submit_block_url(api_version).unwrap();
 
         Ok(self
             .comm_boost

--- a/tests/tests/payloads.rs
+++ b/tests/tests/payloads.rs
@@ -9,19 +9,19 @@ use serde_json::Value;
 #[test]
 fn test_registrations() {
     let data = include_str!("../data/registration_holesky.json");
-    test_encode_decode::<Vec<ValidatorRegistration>>(&data);
+    test_encode_decode::<Vec<ValidatorRegistration>>(data);
 }
 
 #[test]
 fn test_signed_blinded_block() {
     let data = include_str!("../data/signed_blinded_block_holesky.json");
-    test_encode_decode::<SignedBlindedBeaconBlock>(&data);
+    test_encode_decode::<SignedBlindedBeaconBlock>(data);
 }
 
 #[test]
 fn test_submit_block_response() {
     let data = include_str!("../data/submit_block_response_holesky.json");
-    test_encode_decode::<SubmitBlindedBlockResponse>(&data);
+    test_encode_decode::<SubmitBlindedBlockResponse>(data);
 }
 
 // Unhappy path tests
@@ -32,10 +32,8 @@ fn test_missing_registration_field(field_name: &str) -> String {
     // Remove specified field from the first validator's message
     if let Value::Array(arr) = &mut values {
         if let Some(first_validator) = arr.get_mut(0) {
-            if let Some(message) = first_validator.get_mut("message") {
-                if let Value::Object(msg_obj) = message {
-                    msg_obj.remove(field_name);
-                }
+            if let Some(Value::Object(msg_obj)) = first_validator.get_mut("message") {
+                msg_obj.remove(field_name);
             }
         }
     }
@@ -66,10 +64,8 @@ fn test_missing_signed_blinded_block_field(field_name: &str) -> String {
     let mut values: Value = serde_json::from_str(data).unwrap();
 
     // Remove specified field from the message
-    if let Some(message) = values.get_mut("message") {
-        if let Value::Object(msg_obj) = message {
-            msg_obj.remove(field_name);
-        }
+    if let Some(Value::Object(msg_obj)) = values.get_mut("message") {
+        msg_obj.remove(field_name);
     }
 
     // This should fail since the field is required

--- a/tests/tests/pbs_get_header.rs
+++ b/tests/tests/pbs_get_header.rs
@@ -67,7 +67,7 @@ async fn test_get_header() -> Result<()> {
 async fn test_get_header_returns_204_if_relay_down() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 3300;
@@ -101,7 +101,7 @@ async fn test_get_header_returns_204_if_relay_down() -> Result<()> {
 async fn test_get_header_returns_400_if_request_is_invalid() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 3400;

--- a/tests/tests/pbs_get_status.rs
+++ b/tests/tests/pbs_get_status.rs
@@ -19,7 +19,7 @@ use tracing::info;
 async fn test_get_status() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 3500;
@@ -55,7 +55,7 @@ async fn test_get_status() -> Result<()> {
 async fn test_get_status_returns_502_if_relay_down() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 3600;

--- a/tests/tests/pbs_mux.rs
+++ b/tests/tests/pbs_mux.rs
@@ -20,7 +20,7 @@ use tracing::info;
 async fn test_mux() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 3700;
@@ -82,10 +82,15 @@ async fn test_mux() -> Result<()> {
     assert_eq!(mock_validator.do_register_validator().await?.status(), StatusCode::OK);
     assert_eq!(mock_state.received_register_validator(), 3); // default + 2 mux relays were used
 
-    // Submit block requests should go to all relays
-    info!("Sending submit block");
-    assert_eq!(mock_validator.do_submit_block(None).await?.status(), StatusCode::OK);
+    // v1 Submit block requests should go to all relays
+    info!("Sending submit block v1");
+    assert_eq!(mock_validator.do_submit_block_v1(None).await?.status(), StatusCode::OK);
     assert_eq!(mock_state.received_submit_block(), 3); // default + 2 mux relays were used
+
+    // v2 Submit block requests should go to all relays
+    info!("Sending submit block v2");
+    assert_eq!(mock_validator.do_submit_block_v2(None).await?.status(), StatusCode::ACCEPTED);
+    assert_eq!(mock_state.received_submit_block(), 6); // default + 2 mux relays were used
 
     Ok(())
 }

--- a/tests/tests/pbs_post_validators.rs
+++ b/tests/tests/pbs_post_validators.rs
@@ -20,7 +20,7 @@ use tracing::info;
 async fn test_register_validators() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 4000;
@@ -66,7 +66,7 @@ async fn test_register_validators() -> Result<()> {
 async fn test_register_validators_returns_422_if_request_is_malformed() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 4100;
@@ -206,7 +206,7 @@ async fn test_register_validators_returns_422_if_request_is_malformed() -> Resul
 async fn test_register_validators_does_not_retry_on_429() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 4200;
@@ -259,7 +259,7 @@ async fn test_register_validators_does_not_retry_on_429() -> Result<()> {
 async fn test_register_validators_retries_on_500() -> Result<()> {
     setup_test_env();
     let signer = random_secret();
-    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk()).into();
+    let pubkey: BlsPublicKey = blst_pubkey_to_alloy(&signer.sk_to_pk());
 
     let chain = Chain::Holesky;
     let pbs_port = 4300;


### PR DESCRIPTION
This adds support for the [new v2 spec for blinded block publishing](https://ethereum.github.io/builder-specs/?urls.primaryName=dev#/Builder/submitBlindedBlockV2) which is part of Fusaka. In v2, instead of a `200 OK` with the entire block, the builder needs to return `202 ACCEPTED` with an empty body. Implementation-wise there aren't many changes to the existing publishing pipeline, but the return value is now an Option since the unblinded block isn't provided in v2.