### PR TITLE
Release v0.8.1-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "builder_log"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "async-trait",
  "commit-boost",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "cb-bench-pbs"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "alloy",
  "cb-common",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "cb-cli"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "cb-common",
  "clap",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "cb-common"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "aes 0.8.4",
  "alloy",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "cb-metrics"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "axum 0.8.1",
  "cb-common",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "cb-pbs"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "cb-signer"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "alloy",
  "axum 0.8.1",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "cb-tests"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "alloy",
  "axum 0.8.1",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "commit-boost"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "cb-cli",
  "cb-common",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "da_commit"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "alloy",
  "color-eyre",
@@ -4766,7 +4766,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "status_api"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 dependencies = [
  "async-trait",
  "axum 0.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.83"
-version = "0.8.0"
+version = "0.8.1-rc.1"
 
 [workspace.dependencies]
 aes = "0.8"


### PR DESCRIPTION
This is for releasing `v0.8.1-rc.1`. Updates include some docs tweaks, Nimbus key support, Fusaka support, and some PBS logging  and optimization improvements.