### PR TITLE
Add `x-timeout-ms` header support

### DIFF
--- a/crates/common/src/pbs/constants.rs
+++ b/crates/common/src/pbs/constants.rs
@@ -16,6 +16,7 @@ pub const RELOAD_PATH: &str = "/reload";
 pub const HEADER_VERSION_KEY: &str = "X-CommitBoost-Version";
 pub const HEADER_VERSION_VALUE: &str = COMMIT_BOOST_VERSION;
 pub const HEADER_START_TIME_UNIX_MS: &str = "Date-Milliseconds";
+pub const HEADER_TIMEOUT_MS: &str = "X-Timeout-Ms";
 
 pub const BUILDER_EVENTS_PATH: &str = "/builder_events";
 pub const DEFAULT_PBS_JWT_KEY: &str = "DEFAULT_PBS";


### PR DESCRIPTION
This addresses #362 by adding support for the `X-Timeout-Ms` header to incoming `/getHeader` requests.

Since the PBS service already calculates the remaining time in a slot and has a configuration setting for a timeout variable anyway, this just puts whatever timeout is left into that header and sends it to the relay. However, if the proposer provides a valid header value within its request, this will use whichever of those two is shortest. It wouldn't make sense for the proposer to request a longer timeout than would actually be possible before missing the slot, hence why the minimum is used.