### PR TITLE
Log latency for PBS HTTP responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "tower-http",
  "tracing",
  "tree_hash",
  "url",
@@ -5663,6 +5664,22 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 toml = "0.8.13"
 tonic = { version = "0.12.3", features = ["channel", "prost", "tls"] }
 tonic-build = "0.12.3"
+tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }

--- a/crates/pbs/Cargo.toml
+++ b/crates/pbs/Cargo.toml
@@ -20,6 +20,7 @@ prometheus.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tower-http.workspace = true
 tracing.workspace = true
 tree_hash.workspace = true
 url.workspace = true


### PR DESCRIPTION
This adds a log line to the end of PBS's responses, indicating the status code and total time taken to respond to the request. It should help narrow down the causes of unexpected latency in responses.