### PR TITLE
Removed old dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,6 @@ dependencies = [
  "docker-compose-types",
  "eyre",
  "indexmap 2.8.0",
- "rcgen",
  "serde_yaml",
 ]
 
@@ -1610,7 +1609,6 @@ dependencies = [
  "pbkdf2 0.12.2",
  "rand 0.9.0",
  "rayon",
- "rcgen",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,5 +11,4 @@ clap.workspace = true
 docker-compose-types.workspace = true
 eyre.workspace = true
 indexmap.workspace = true
-rcgen.workspace = true
 serde_yaml.workspace = true

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -29,7 +29,6 @@ lh_types.workspace = true
 pbkdf2.workspace = true
 rand.workspace = true
 rayon.workspace = true
-rcgen.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Follow-on from https://github.com/Commit-Boost/commit-boost-client/pull/357#discussion_r2319700642. This just removes rcgen from some of the crates that don't need it anymore.