### PR TITLE
Update Prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -4218,7 +4218,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -4306,9 +4306,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "quick-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ lh_eth2_keystore = { package = "eth2_keystore", git = "https://github.com/sigp/l
 lh_types = { package = "types", git = "https://github.com/sigp/lighthouse", tag = "v7.1.0" }
 parking_lot = "0.12.3"
 pbkdf2 = "0.12.2"
-prometheus = "0.13.4"
+prometheus = "0.14.0"
 prost = "0.13.4"
 rand = { version = "0.9", features = ["os_rng"] }
 rayon = "1.10.0"


### PR DESCRIPTION
This updates the Prometheus crate up from `0.13.4` to `0.14.0`, which is needed to fix a vulnerability in Protobuf that the security audit was flagging.