### PR TITLE
Fix misc findings from reaudit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,6 +1679,7 @@ dependencies = [
  "blsful",
  "cb-common",
  "cb-metrics",
+ "client-ip",
  "eyre",
  "futures",
  "headers",
@@ -1836,6 +1837,16 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "client-ip"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31211fc26899744f5b22521fdc971e5f3875991d8880537537470685a0e9552d"
+dependencies = [
+ "forwarded-header-value",
+ "http",
+]
 
 [[package]]
 name = "cmake"
@@ -2827,6 +2838,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3948,6 +3969,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "tree_hash",
  "url",
 ]
@@ -6191,6 +6192,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cb-pbs = { path = "crates/pbs" }
 cb-signer = { path = "crates/signer" }
 cipher = "0.4"
 clap = { version = "4.5.4", features = ["derive", "env"] }
+client-ip = { version = "0.1.1", features = [ "forwarded-header" ] }
 color-eyre = "0.6.3"
 const_format = "0.2.34"
 ctr = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 tree_hash = "0.9"
 tree_hash_derive = "0.9"
 typenum = "1.17.0"

--- a/api/signer-api.yml
+++ b/api/signer-api.yml
@@ -15,6 +15,7 @@ paths:
         
         The token **must include** the following claims:
         - `exp` (integer): Expiration timestamp
+        - `route` (string): The route being requested (must be `/signer/v1/get_pubkeys` for this endpoint).
         - `module` (string): The ID of the module making the request, which must match a module ID in the Commit-Boost configuration file.
       tags:
         - Signer
@@ -73,6 +74,7 @@ paths:
         The token **must include** the following claims:
         - `exp` (integer): Expiration timestamp
         - `module` (string): The ID of the module making the request, which must match a module ID in the Commit-Boost configuration file.
+        - `route` (string): The route being requested (must be `/signer/v1/request_signature/bls` for this endpoint).
         - `payload_hash` (string): The Keccak-256 hash of the JSON-encoded request body, with optional `0x` prefix. This is required to prevent JWT replay attacks.
       tags:
         - Signer
@@ -220,6 +222,7 @@ paths:
         The token **must include** the following claims:
         - `exp` (integer): Expiration timestamp
         - `module` (string): The ID of the module making the request, which must match a module ID in the Commit-Boost configuration file.
+        - `route` (string): The route being requested (must be `/signer/v1/request_signature/proxy-bls` for this endpoint).
         - `payload_hash` (string): The Keccak-256 hash of the JSON-encoded request body, with optional `0x` prefix. This is required to prevent JWT replay attacks.
       tags:
         - Signer
@@ -367,6 +370,7 @@ paths:
         The token **must include** the following claims:
         - `exp` (integer): Expiration timestamp
         - `module` (string): The ID of the module making the request, which must match a module ID in the Commit-Boost configuration file.
+        - `route` (string): The route being requested (must be `/signer/v1/request_signature/proxy-ecdsa` for this endpoint).
         - `payload_hash` (string): The Keccak-256 hash of the JSON-encoded request body, with optional `0x` prefix. This is required to prevent JWT replay attacks.
       tags:
         - Signer
@@ -514,6 +518,7 @@ paths:
         The token **must include** the following claims:
         - `exp` (integer): Expiration timestamp
         - `module` (string): The ID of the module making the request, which must match a module ID in the Commit-Boost configuration file.
+        - `route` (string): The route being requested (must be `/signer/v1/generate_proxy_key` for this endpoint).
         - `payload_hash` (string): The Keccak-256 hash of the JSON-encoded request body, with optional `0x` prefix. This is required to prevent JWT replay attacks.
       tags:
         - Signer

--- a/config.example.toml
+++ b/config.example.toml
@@ -165,7 +165,8 @@ port = 20000
 # Number of JWT authentication attempts a client can fail before blocking that client temporarily from Signer access
 # OPTIONAL, DEFAULT: 3
 jwt_auth_fail_limit = 3
-# How long to block a client from Signer access, in seconds, if it failed JWT authentication too many times
+# How long to block a client from Signer access, in seconds, if it failed JWT authentication too many times.
+# This also defines the interval at which failed attempts are regularly checked and expired ones are cleaned up.
 # OPTIONAL, DEFAULT: 300
 jwt_auth_fail_timeout_seconds = 300
 

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -88,7 +88,8 @@ pub struct SignerConfig {
     pub jwt_auth_fail_limit: u32,
 
     /// Duration in seconds to rate limit an endpoint after the JWT auth failure
-    /// limit has been reached
+    /// limit has been reached. This also defines the interval at which failed
+    /// attempts are regularly checked and expired ones are cleaned up.
     #[serde(default = "default_u32::<SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT>")]
     pub jwt_auth_fail_timeout_seconds: u32,
 

--- a/crates/common/src/signer/store.rs
+++ b/crates/common/src/signer/store.rs
@@ -244,14 +244,14 @@ impl ProxyStore {
                                         serde_json::from_str(&file_content)?;
                                     let signer =
                                         EcdsaSigner::new_from_bytes(&key_and_delegation.secret)?;
-                                    let pubkey = signer.address();
+                                    let address = signer.address();
                                     let proxy_signer = EcdsaProxySigner {
                                         signer,
                                         delegation: key_and_delegation.delegation,
                                     };
 
-                                    proxy_signers.ecdsa_signers.insert(pubkey, proxy_signer);
-                                    ecdsa_map.entry(module_id.clone()).or_default().push(pubkey);
+                                    proxy_signers.ecdsa_signers.insert(address, proxy_signer);
+                                    ecdsa_map.entry(module_id.clone()).or_default().push(address);
                                 }
                             }
                         }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -26,6 +26,7 @@ pub struct Jwt(pub String);
 pub struct JwtClaims {
     pub exp: u64,
     pub module: ModuleId,
+    pub route: String,
     pub payload_hash: Option<B256>,
 }
 
@@ -33,6 +34,7 @@ pub struct JwtClaims {
 pub struct JwtAdminClaims {
     pub exp: u64,
     pub admin: bool,
+    pub route: String,
     pub payload_hash: Option<B256>,
 }
 

--- a/crates/signer/Cargo.toml
+++ b/crates/signer/Cargo.toml
@@ -14,6 +14,7 @@ bimap.workspace = true
 blsful.workspace = true
 cb-common.workspace = true
 cb-metrics.workspace = true
+client-ip.workspace = true
 eyre.workspace = true
 futures.workspace = true
 headers.workspace = true

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -36,6 +36,7 @@ use cb_common::{
     utils::{decode_jwt, validate_admin_jwt, validate_jwt},
 };
 use cb_metrics::provider::MetricsProvider;
+use client_ip::*;
 use eyre::Context;
 use headers::{Authorization, authorization::Bearer};
 use parking_lot::RwLock as ParkingRwLock;
@@ -225,25 +226,34 @@ fn mark_jwt_failure(state: &SigningState, client_ip: IpAddr) {
 
 /// Get the true client IP from the request headers or fallback to the socket
 /// address
-fn get_true_ip(req_headers: &HeaderMap, addr: &SocketAddr) -> IpAddr {
-    // Try the X-Forwarded-For header first
-    if let Some(true_ip) = req_headers.get("x-forwarded-for") &&
-        let Ok(true_ip) = true_ip.to_str() &&
-        let Ok(true_ip) = true_ip.parse()
-    {
-        return true_ip;
-    }
+fn get_true_ip(req_headers: &HeaderMap, addr: &SocketAddr) -> eyre::Result<IpAddr> {
+    let ip_extractors = [
+        cf_connecting_ip,
+        cloudfront_viewer_address,
+        fly_client_ip,
+        rightmost_forwarded,
+        rightmost_x_forwarded_for,
+        true_client_ip,
+        x_real_ip,
+    ];
 
-    // Then try the X-Real-IP header
-    if let Some(true_ip) = req_headers.get("x-real-ip") &&
-        let Ok(true_ip) = true_ip.to_str() &&
-        let Ok(true_ip) = true_ip.parse()
-    {
-        return true_ip;
+    // Run each extractor in order and return the first valid IP found
+    for extractor in ip_extractors {
+        match extractor(req_headers) {
+            Ok(true_ip) => {
+                return Ok(true_ip);
+            }
+            Err(e) => {
+                match e {
+                    Error::AbsentHeader { .. } => continue, // Missing headers are fine
+                    _ => return Err(eyre::eyre!(e.to_string())), // Report anything else
+                }
+            }
+        }
     }
 
     // Fallback to the socket IP
-    addr.ip()
+    Ok(addr.ip())
 }
 
 /// Authentication middleware layer
@@ -256,7 +266,10 @@ async fn jwt_auth(
     next: Next,
 ) -> Result<Response, SignerModuleError> {
     // Check if the request needs to be rate limited
-    let client_ip = get_true_ip(&req_headers, &addr);
+    let client_ip = get_true_ip(&req_headers, &addr).map_err(|e| {
+        error!("Failed to get client IP: {e}");
+        SignerModuleError::RequestError("failed to get client IP".to_string())
+    })?;
     check_jwt_rate_limit(&state, &client_ip)?;
 
     // Clone the request so we can read the body
@@ -359,7 +372,10 @@ async fn admin_auth(
     next: Next,
 ) -> Result<Response, SignerModuleError> {
     // Check if the request needs to be rate limited
-    let client_ip = get_true_ip(&req_headers, &addr);
+    let client_ip = get_true_ip(&req_headers, &addr).map_err(|e| {
+        error!("Failed to get client IP: {e}");
+        SignerModuleError::RequestError("failed to get client IP".to_string())
+    })?;
     check_jwt_rate_limit(&state, &client_ip)?;
 
     // Clone the request so we can read the body

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -143,6 +143,22 @@ impl SigningService {
             .route_layer(middleware::from_fn(log_request))
             .route(STATUS_PATH, get(handle_status));
 
+        // Run the JWT cleaning task
+        let jwt_cleaning_task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(state.jwt_auth_fail_timeout);
+            loop {
+                interval.tick().await;
+                let mut failures = state.jwt_auth_failures.write().await;
+                let before = failures.len();
+                failures
+                    .retain(|_, info| info.last_failure.elapsed() < state.jwt_auth_fail_timeout);
+                let after = failures.len();
+                if before != after {
+                    debug!("Cleaned up {} old JWT auth failure entries", before - after);
+                }
+            }
+        });
+
         let server_result = if let Some(tls_config) = config.tls_certificates {
             if CryptoProvider::get_default().is_none() {
                 // Install the AWS-LC provider if no default is set, usually for CI
@@ -184,6 +200,10 @@ impl SigningService {
                 )
                 .await
         };
+
+        // Shutdown the JWT cleaning task
+        jwt_cleaning_task.abort();
+
         server_result.wrap_err("signer service exited")
     }
 

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -213,10 +213,7 @@ impl SigningService {
 }
 
 /// Marks a JWT authentication failure for a given client IP
-fn mark_jwt_failure(
-    client_ip: IpAddr,
-    failures: &mut RwLockWriteGuard<HashMap<IpAddr, JwtAuthFailureInfo>>,
-) {
+fn mark_jwt_failure(client_ip: IpAddr, failures: &mut HashMap<IpAddr, JwtAuthFailureInfo>) {
     let failure_info = failures
         .entry(client_ip)
         .or_insert(JwtAuthFailureInfo { failure_count: 0, last_failure: Instant::now() });

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tree_hash.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+tracing-test.workspace = true

--- a/tests/tests/signer_jwt_auth.rs
+++ b/tests/tests/signer_jwt_auth.rs
@@ -177,7 +177,7 @@ async fn test_signer_admin_jwt_rate_limit() -> Result<()> {
     let admin_secret = ADMIN_SECRET.to_string();
     let module_id = ModuleId(JWT_MODULE.to_string());
     let mod_cfgs = create_mod_signing_configs().await;
-    let start_config = start_server(20500, &mod_cfgs, admin_secret.clone(), false).await?;
+    let start_config = start_server(20510, &mod_cfgs, admin_secret.clone(), false).await?;
 
     let revoke_body = RevokeModuleRequest { module_id: ModuleId(JWT_MODULE.to_string()) };
     let body_bytes = serde_json::to_vec(&revoke_body)?;

--- a/tests/tests/signer_jwt_auth_cleanup.rs
+++ b/tests/tests/signer_jwt_auth_cleanup.rs
@@ -1,0 +1,70 @@
+use std::{collections::HashMap, time::Duration};
+
+use alloy::primitives::b256;
+use cb_common::{
+    commit::constants::GET_PUBKEYS_PATH,
+    config::{ModuleSigningConfig, load_module_signing_configs},
+    types::ModuleId,
+    utils::create_jwt,
+};
+use cb_tests::{
+    signer_service::start_server,
+    utils::{self},
+};
+use eyre::Result;
+use reqwest::StatusCode;
+
+const JWT_MODULE: &str = "test-module";
+const JWT_SECRET: &str = "test-jwt-secret";
+const ADMIN_SECRET: &str = "test-admin-secret";
+
+async fn create_mod_signing_configs() -> HashMap<ModuleId, ModuleSigningConfig> {
+    let mut cfg =
+        utils::get_commit_boost_config(utils::get_pbs_static_config(utils::get_pbs_config(0)));
+
+    let module_id = ModuleId(JWT_MODULE.to_string());
+    let signing_id = b256!("0101010101010101010101010101010101010101010101010101010101010101");
+
+    cfg.modules = Some(vec![utils::create_module_config(module_id.clone(), signing_id)]);
+
+    let jwts = HashMap::from([(module_id.clone(), JWT_SECRET.to_string())]);
+
+    load_module_signing_configs(&cfg, &jwts).unwrap()
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_signer_jwt_fail_cleanup() -> Result<()> {
+    // setup_test_env() isn't used because we want to capture logs with tracing_test
+    let module_id = ModuleId(JWT_MODULE.to_string());
+    let mod_cfgs = create_mod_signing_configs().await;
+    let start_config = start_server(20102, &mod_cfgs, ADMIN_SECRET.to_string(), false).await?;
+    let mod_cfg = mod_cfgs.get(&module_id).expect("JWT config for test module not found");
+
+    // Run as many pubkeys requests as the fail limit
+    let jwt = create_jwt(&module_id, "incorrect secret", GET_PUBKEYS_PATH, None)?;
+    let client = reqwest::Client::new();
+    let url = format!("http://{}{}", start_config.endpoint, GET_PUBKEYS_PATH);
+    for _ in 0..start_config.jwt_auth_fail_limit {
+        let response = client.get(&url).bearer_auth(&jwt).send().await?;
+        assert!(response.status() == StatusCode::UNAUTHORIZED);
+    }
+
+    // Run another request - this should fail due to rate limiting now
+    let jwt = create_jwt(&module_id, &mod_cfg.jwt_secret, GET_PUBKEYS_PATH, None)?;
+    let response = client.get(&url).bearer_auth(&jwt).send().await?;
+    assert!(response.status() == StatusCode::TOO_MANY_REQUESTS);
+
+    // Wait until the cleanup task should have run properly, takes a while for the
+    // timing to work out
+    tokio::time::sleep(Duration::from_secs(
+        (start_config.jwt_auth_fail_timeout_seconds * 3) as u64,
+    ))
+    .await;
+
+    // Make sure the cleanup message was logged - it's all internal state so without
+    // refactoring or exposing it, this is the easiest way to check if it triggered
+    assert!(logs_contain("Cleaned up 1 old JWT auth failure entries"));
+
+    Ok(())
+}

--- a/tests/tests/signer_request_sig.rs
+++ b/tests/tests/signer_request_sig.rs
@@ -62,7 +62,12 @@ async fn test_signer_sign_request_good() -> Result<()> {
     let pubkey = BlsPublicKey::deserialize(&PUBKEY_1).unwrap();
     let request = SignConsensusRequest { pubkey: pubkey.clone(), object_root, nonce };
     let payload_bytes = serde_json::to_vec(&request)?;
-    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, Some(&payload_bytes))?;
+    let jwt = create_jwt(
+        &module_id,
+        &jwt_config.jwt_secret,
+        REQUEST_SIGNATURE_BLS_PATH,
+        Some(&payload_bytes),
+    )?;
     let client = reqwest::Client::new();
     let url = format!("http://{}{}", start_config.endpoint, REQUEST_SIGNATURE_BLS_PATH);
     let response = client.post(&url).json(&request).bearer_auth(&jwt).send().await?;
@@ -100,7 +105,12 @@ async fn test_signer_sign_request_different_module() -> Result<()> {
     let pubkey = BlsPublicKey::deserialize(&PUBKEY_1).unwrap();
     let request = SignConsensusRequest { pubkey: pubkey.clone(), object_root, nonce };
     let payload_bytes = serde_json::to_vec(&request)?;
-    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, Some(&payload_bytes))?;
+    let jwt = create_jwt(
+        &module_id,
+        &jwt_config.jwt_secret,
+        REQUEST_SIGNATURE_BLS_PATH,
+        Some(&payload_bytes),
+    )?;
     let client = reqwest::Client::new();
     let url = format!("http://{}{}", start_config.endpoint, REQUEST_SIGNATURE_BLS_PATH);
     let response = client.post(&url).json(&request).bearer_auth(&jwt).send().await?;
@@ -146,7 +156,12 @@ async fn test_signer_sign_request_incorrect_hash() -> Result<()> {
     let true_object_root =
         b256!("0x0123456789012345678901234567890123456789012345678901234567890123");
     let true_request = SignConsensusRequest { pubkey, object_root: true_object_root, nonce };
-    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, Some(&fake_payload_bytes))?;
+    let jwt = create_jwt(
+        &module_id,
+        &jwt_config.jwt_secret,
+        REQUEST_SIGNATURE_BLS_PATH,
+        Some(&fake_payload_bytes),
+    )?;
     let client = reqwest::Client::new();
     let url = format!("http://{}{}", start_config.endpoint, REQUEST_SIGNATURE_BLS_PATH);
     let response = client.post(&url).json(&true_request).bearer_auth(&jwt).send().await?;
@@ -171,7 +186,7 @@ async fn test_signer_sign_request_missing_hash() -> Result<()> {
     let pubkey = BlsPublicKey::deserialize(&PUBKEY_1).unwrap();
     let object_root = b256!("0x0123456789012345678901234567890123456789012345678901234567890123");
     let request = SignConsensusRequest { pubkey, object_root, nonce };
-    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, None)?;
+    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, REQUEST_SIGNATURE_BLS_PATH, None)?;
     let client = reqwest::Client::new();
     let url = format!("http://{}{}", start_config.endpoint, REQUEST_SIGNATURE_BLS_PATH);
     let response = client.post(&url).json(&request).bearer_auth(&jwt).send().await?;

--- a/tests/tests/signer_tls.rs
+++ b/tests/tests/signer_tls.rs
@@ -41,7 +41,7 @@ async fn test_signer_tls() -> Result<()> {
     let jwt_config = mod_cfgs.get(&module_id).expect("JWT config for test module not found");
 
     // Run a pubkeys request
-    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, None)?;
+    let jwt = create_jwt(&module_id, &jwt_config.jwt_secret, GET_PUBKEYS_PATH, None)?;
     let cert = match start_config.tls_certificates {
         Some(ref certificates) => &certificates.0,
         None => bail!("TLS certificates not found in start config"),


### PR DESCRIPTION
# Work In Progress

This fixes several smaller miscellaneous findings from the reaudit assessment.

## CBST2-01
- Added path / route to the JWT claims to improve resilience against replaying.

## CBST2-04
- Added rate-limit flagging to admin route JWT auth checking.
- `handle_reload()` now updates the state atomically once all of the code has succeeded, and doesn't update it at all if any failures occur.

## CBST2-06
- JWT auth checking now attempts to retrieve the rightmost client IP from various proxy forwarding headers, then the falls back to the direct connection IP.
- ~~Fixed a race that occurred due to differing locks on JWT auth failure reads and writes.~~ This was reverted due to performance considerations with locking the auth check for each request.
- (Done in #380) Added a task to periodically sweep and clean up expired JWT authorization failures. 

## CBST2-14
- Renamed a misnamed variable.