### PR TITLE
Add a task to clean up expired JWT failure rate limits 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "tree_hash",
  "url",
 ]
@@ -6191,6 +6192,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 tree_hash = "0.9"
 tree_hash_derive = "0.9"
 typenum = "1.17.0"

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -88,7 +88,8 @@ pub struct SignerConfig {
     pub jwt_auth_fail_limit: u32,
 
     /// Duration in seconds to rate limit an endpoint after the JWT auth failure
-    /// limit has been reached
+    /// limit has been reached. This also defines the interval at which failed
+    /// attempts are regularly checked and expired ones are cleaned up.
     #[serde(default = "default_u32::<SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT>")]
     pub jwt_auth_fail_timeout_seconds: u32,
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tree_hash.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+tracing-test.workspace = true

--- a/tests/tests/signer_jwt_auth.rs
+++ b/tests/tests/signer_jwt_auth.rs
@@ -208,3 +208,40 @@ async fn test_signer_admin_jwt_rate_limit() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn test_signer_jwt_fail_cleanup() -> Result<()> {
+    // setup_test_env() isn't used because we want to capture logs with tracing_test
+    let module_id = ModuleId(JWT_MODULE.to_string());
+    let mod_cfgs = create_mod_signing_configs().await;
+    let start_config = start_server(20102, &mod_cfgs, ADMIN_SECRET.to_string(), false).await?;
+    let mod_cfg = mod_cfgs.get(&module_id).expect("JWT config for test module not found");
+
+    // Run as many pubkeys requests as the fail limit
+    let jwt = create_jwt(&module_id, "incorrect secret", GET_PUBKEYS_PATH, None)?;
+    let client = reqwest::Client::new();
+    let url = format!("http://{}{}", start_config.endpoint, GET_PUBKEYS_PATH);
+    for _ in 0..start_config.jwt_auth_fail_limit {
+        let response = client.get(&url).bearer_auth(&jwt).send().await?;
+        assert!(response.status() == StatusCode::UNAUTHORIZED);
+    }
+
+    // Run another request - this should fail due to rate limiting now
+    let jwt = create_jwt(&module_id, &mod_cfg.jwt_secret, GET_PUBKEYS_PATH, None)?;
+    let response = client.get(&url).bearer_auth(&jwt).send().await?;
+    assert!(response.status() == StatusCode::TOO_MANY_REQUESTS);
+
+    // Wait until the cleanup task should have run properly, takes a while for the
+    // timing to work out
+    tokio::time::sleep(Duration::from_secs(
+        (start_config.jwt_auth_fail_timeout_seconds * 3) as u64,
+    ))
+    .await;
+
+    // Make sure the cleanup message was logged - it's all internal state so without
+    // refactoring or exposing it, this is the easiest way to check if it triggered
+    assert!(logs_contain("Cleaned up 1 old JWT auth failure entries"));
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a small task that runs in parallel with the Signer server and periodically cleans up the JWT auth failure map, removing any rate limiting entries that have expired. Previously the only way they got removed was if the timed out client tried to request again after the timeout period, so if lots of clients never re-requested then they'd just fill up the map for no reason.

Note that the attempt count isn't timed, so if a client fails 2/3 attempts, then waits 10 minutes, then fails a 3rd attempt, they'll trigger the lockout.