### PR TITLE
fix(signer): Mark a JWT failure if payload conversion fail

### DIFF
--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -277,6 +277,7 @@ async fn jwt_auth(
     let path = parts.uri.path();
     let bytes = to_bytes(body, REQUEST_MAX_BODY_LENGTH).await.map_err(|e| {
         error!("Failed to read request body: {e}");
+        mark_jwt_failure(&state, client_ip);
         SignerModuleError::RequestError(e.to_string())
     })?;
 
@@ -291,7 +292,10 @@ async fn jwt_auth(
             mark_jwt_failure(&state, client_ip);
             Err(SignerModuleError::Unauthorized)
         }
-        Err(err) => Err(err),
+        Err(err) => {
+            mark_jwt_failure(&state, client_ip);
+            Err(err)
+        }
     }
 }
 
@@ -383,6 +387,7 @@ async fn admin_auth(
     let path = parts.uri.path();
     let bytes = to_bytes(body, REQUEST_MAX_BODY_LENGTH).await.map_err(|e| {
         error!("Failed to read request body: {e}");
+        mark_jwt_failure(&state, client_ip);
         SignerModuleError::RequestError(e.to_string())
     })?;
 


### PR DESCRIPTION
We weren't marking a failure request if the payload conversion to `Bytes` failed (e.g., because of exceeding the max body length). This could lead to a rate limit bypass for DoS