### PR TITLE
feat(docs): add submodule initialization

### DIFF
--- a/docs/docs/get_started/overview.md
+++ b/docs/docs/get_started/overview.md
@@ -40,6 +40,9 @@ git clone https://github.com/Commit-Boost/commit-boost-client
 
 # Stable branch has the latest released version
 git checkout stable
+
+# Init submodules
+git submodule update --init --recursive
 ```
 
 :::note


### PR DESCRIPTION
Avoid build failures when running `cargo build --release --bin commit-boost-cli` due to missing protobuf dependency.