### PR TITLE
Update to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "cb-bench-pbs"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "alloy",
  "cb-common",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "cb-cli"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "cb-common",
  "clap",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "cb-common"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "aes 0.8.4",
  "alloy",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "cb-metrics"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "axum 0.8.4",
  "cb-common",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "cb-pbs"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "cb-signer"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "alloy",
  "axum 0.8.4",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "cb-tests"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "alloy",
  "axum 0.8.4",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "commit-boost"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "cb-cli",
  "cb-common",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "da_commit"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "alloy",
  "color-eyre",
@@ -6076,7 +6076,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "status_api"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "axum 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.89"
-version = "0.8.1-rc.4"
+version = "0.8.1"
 
 [workspace.dependencies]
 aes = "0.8"


### PR DESCRIPTION
Updates the version to the next stable release, v0.8.1. There's a lot in here so it may be more prudent to use v0.9.0 instead of just removing the RC tag.