### PR TITLE
fix: spawn get payload in the background

### DIFF
--- a/crates/common/src/pbs/error.rs
+++ b/crates/common/src/pbs/error.rs
@@ -25,6 +25,9 @@ pub enum PbsError {
 
     #[error("URL parsing error: {0}")]
     UrlParsing(#[from] url::ParseError),
+
+    #[error("tokio join error: {0}")]
+    TokioJoinError(#[from] tokio::task::JoinError),
 }
 
 impl PbsError {

--- a/crates/pbs/src/api.rs
+++ b/crates/pbs/src/api.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use axum::{Router, http::HeaderMap};
 use cb_common::pbs::{
@@ -34,10 +36,10 @@ pub trait BuilderApi<S: BuilderApiState>: 'static {
     /// https://ethereum.github.io/builder-specs/#/Builder/submitBlindedBlock and
     /// https://ethereum.github.io/builder-specs/#/Builder/submitBlindedBlockV2
     async fn submit_block(
-        signed_blinded_block: SignedBlindedBeaconBlock,
+        signed_blinded_block: Arc<SignedBlindedBeaconBlock>,
         req_headers: HeaderMap,
         state: PbsState<S>,
-        api_version: &BuilderApiVersion,
+        api_version: BuilderApiVersion,
     ) -> eyre::Result<Option<SubmitBlindedBlockResponse>> {
         mev_boost::submit_block(signed_blinded_block, req_headers, state, api_version).await
     }

--- a/crates/pbs/src/routes/submit_block.rs
+++ b/crates/pbs/src/routes/submit_block.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::{Json, extract::State, http::HeaderMap, response::IntoResponse};
 use cb_common::{
     pbs::{BuilderApiVersion, GetPayloadInfo, SignedBlindedBeaconBlock},
@@ -17,7 +19,7 @@ use crate::{
 pub async fn handle_submit_block_v1<S: BuilderApiState, A: BuilderApi<S>>(
     state: State<PbsStateGuard<S>>,
     req_headers: HeaderMap,
-    signed_blinded_block: Json<SignedBlindedBeaconBlock>,
+    Json(signed_blinded_block): Json<Arc<SignedBlindedBeaconBlock>>,
 ) -> Result<impl IntoResponse, PbsClientError> {
     handle_submit_block_impl::<S, A>(
         state,
@@ -31,7 +33,7 @@ pub async fn handle_submit_block_v1<S: BuilderApiState, A: BuilderApi<S>>(
 pub async fn handle_submit_block_v2<S: BuilderApiState, A: BuilderApi<S>>(
     state: State<PbsStateGuard<S>>,
     req_headers: HeaderMap,
-    signed_blinded_block: Json<SignedBlindedBeaconBlock>,
+    Json(signed_blinded_block): Json<Arc<SignedBlindedBeaconBlock>>,
 ) -> Result<impl IntoResponse, PbsClientError> {
     handle_submit_block_impl::<S, A>(
         state,
@@ -45,7 +47,7 @@ pub async fn handle_submit_block_v2<S: BuilderApiState, A: BuilderApi<S>>(
 async fn handle_submit_block_impl<S: BuilderApiState, A: BuilderApi<S>>(
     State(state): State<PbsStateGuard<S>>,
     req_headers: HeaderMap,
-    Json(signed_blinded_block): Json<SignedBlindedBeaconBlock>,
+    signed_blinded_block: Arc<SignedBlindedBeaconBlock>,
     api_version: BuilderApiVersion,
 ) -> Result<impl IntoResponse, PbsClientError> {
     tracing::Span::current().record("slot", signed_blinded_block.slot().as_u64() as i64);
@@ -65,7 +67,7 @@ async fn handle_submit_block_impl<S: BuilderApiState, A: BuilderApi<S>>(
 
     info!(ua, ms_into_slot = now.saturating_sub(slot_start_ms), "new request");
 
-    match A::submit_block(signed_blinded_block, req_headers, state, &api_version).await {
+    match A::submit_block(signed_blinded_block, req_headers, state, api_version).await {
         Ok(res) => match res {
             Some(block_response) => {
                 trace!(?block_response);


### PR DESCRIPTION
in the v2 endpoint , relays are expected to return 202 after the blinded block has been validated , with the publishing happening async. There might be an edge case where a relay may return 202 but fail to publish the block. Previously we would cancel the request on other relays, but now we let those requests still run in the background to extra redundancy.

Also fixed a small bug, `select_ok`  on a `tokio::spawn` would select over the outer `JoinError` rather than the inner `Result`