### PR TITLE
Update to v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "cb-bench-pbs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "alloy",
  "cb-common",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "cb-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cb-common",
  "clap",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "cb-common"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aes 0.8.4",
  "alloy",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "cb-metrics"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "axum 0.8.4",
  "cb-common",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "cb-pbs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "cb-signer"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "alloy",
  "axum 0.8.4",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "cb-tests"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "alloy",
  "axum 0.8.4",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "commit-boost"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cb-cli",
  "cb-common",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "da_commit"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "alloy",
  "color-eyre",
@@ -6076,7 +6076,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "status_api"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "axum 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.89"
-version = "0.9.1"
+version = "0.9.2"
 
 [workspace.dependencies]
 aes = "0.8"


### PR DESCRIPTION
As found in #399, the v0.9.1 CI release did the initial build with the v0.9.0 codebase. This is just a version bump to do a re-release and avoid confusion or fragmentation.