### PR TITLE
Added the Fulu fork slot for Mainnet

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -233,7 +233,8 @@ impl KnownChain {
 
     pub fn fulu_fork_slot(&self) -> u64 {
         match self {
-            KnownChain::Mainnet | KnownChain::Helder => u64::MAX,
+            KnownChain::Mainnet => 13164544,
+            KnownChain::Helder => u64::MAX,
             KnownChain::Holesky => 5283840,
             KnownChain::Sepolia => 8724480,
             KnownChain::Hoodi => 1622016,


### PR DESCRIPTION
This just adds the Fulu fork slot for Mainnet, which is mainly used by unit tests now but we need it in order to start adding the consensus version header to various calls if it's missing.