### PR TITLE
feat(signer): add a config param to set the max size of `ListAccount` Dirk's response

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -199,6 +199,9 @@ jwt_auth_fail_timeout_seconds = 300
 # Path to the CA certificate that signed the Dirk server certificate
 # OPTIONAL
 # ca_cert_path = "/path/to/ca.crt"
+# Limits the maximum size of a decoded gRPC response
+# OPTIONAL. Default: 4MB
+# max_response_size_bytes = 4194304
 
 # Add one entry like this for each Dirk host
 # [[signer.dirk.hosts]]

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -113,6 +113,9 @@ pub enum SignerType {
         /// How to store proxy key delegations
         /// ERC2335 is not supported with Dirk signer
         store: Option<ProxyStore>,
+        /// Limits the maximum size of a decoded gRPC response.
+        /// Default is 4MB (from tonic bindings)
+        max_response_size_bytes: Option<usize>,
     },
 }
 
@@ -122,6 +125,7 @@ pub struct DirkConfig {
     pub client_cert: Identity,
     pub secrets_path: PathBuf,
     pub cert_auth: Option<Certificate>,
+    pub max_response_size_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -188,7 +192,7 @@ impl StartSignerConfig {
                 secrets_path,
                 ca_cert_path,
                 store,
-                ..
+                max_response_size_bytes,
             } => {
                 let cert_path = load_env_var(DIRK_CERT_ENV).map(PathBuf::from).unwrap_or(cert_path);
                 let key_path = load_env_var(DIRK_KEY_ENV).map(PathBuf::from).unwrap_or(key_path);
@@ -222,6 +226,7 @@ impl StartSignerConfig {
                             }
                             None => None,
                         },
+                        max_response_size_bytes,
                     }),
                 })
             }

--- a/crates/signer/src/manager/dirk.rs
+++ b/crates/signer/src/manager/dirk.rs
@@ -101,7 +101,14 @@ impl DirkManager {
                 }
             };
 
-            let accounts_response = match ListerClient::new(channel.clone())
+            let mut lister_client = ListerClient::new(channel.clone());
+            if let Some(max_decoding_size) = config.max_response_size_bytes {
+                // ListAccounts seems the only method that can return large responses,
+                // so we only set the max decoding size for it.
+                lister_client = lister_client.max_decoding_message_size(max_decoding_size);
+            }
+
+            let accounts_response = match lister_client
                 .list_accounts(ListAccountsRequest { paths: host.wallets.clone() })
                 .await
             {

--- a/docs/docs/get_started/configuration.md
+++ b/docs/docs/get_started/configuration.md
@@ -329,6 +329,7 @@ key_path = "/path/to/client.key"
 secrets_path = "/path/to/secrets"
 # Optional parameters
 ca_cert_path = "/path/to/ca.crt"
+max_response_size_bytes = "4194304"
 
 # Add one entry like this for each host
 [[signer.dirk.hosts]]


### PR DESCRIPTION
Some operators are getting responses larger than the default (4MB) max allowed response size. This changes allow them to set a custom -larger- value