### PR TITLE
Add --version support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cb-metrics = { path = "crates/metrics" }
 cb-pbs = { path = "crates/pbs" }
 cb-signer = { path = "crates/signer" }
 cipher = "0.4"
-clap = { version = "4.5.4", features = ["derive", "env"] }
+clap = { version = "4.5.48", features = ["derive", "env"] }
 color-eyre = "0.6.3"
 ctr = "0.9.2"
 derive_more = { version = "2.0.1", features = ["deref", "display", "from", "into"] }

--- a/bin/cli.rs
+++ b/bin/cli.rs
@@ -1,8 +1,20 @@
 use clap::Parser;
 
+/// Version string with a leading 'v'
+const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
+
+/// Subcommands and global arguments for the module
+#[derive(Parser, Debug)]
+#[command(name = "Commit-Boost CLI", version = VERSION, about, long_about = None)]
+struct Cli {}
+
 /// Main entry point of the Commit-Boost CLI
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    // Parse the CLI arguments (currently only used for version info, more can be
+    // added later)
+    let _cli = Cli::parse();
+
     color_eyre::install()?;
     // set default backtrace unless provided
 

--- a/bin/pbs.rs
+++ b/bin/pbs.rs
@@ -7,8 +7,20 @@ use clap::Parser;
 use eyre::Result;
 use tracing::{error, info};
 
+/// Version string with a leading 'v'
+const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
+
+/// Subcommands and global arguments for the module
+#[derive(Parser, Debug)]
+#[command(name = "Commit-Boost PBS Service", version = VERSION, about, long_about = None)]
+struct Cli {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Parse the CLI arguments (currently only used for version info, more can be
+    // added later)
+    let _cli = Cli::parse();
+
     color_eyre::install()?;
 
     let _guard = initialize_tracing_log(PBS_MODULE_NAME, LogsSettings::from_env_config()?);

--- a/bin/signer.rs
+++ b/bin/signer.rs
@@ -7,8 +7,20 @@ use clap::Parser;
 use eyre::Result;
 use tracing::{error, info};
 
+/// Version string with a leading 'v'
+const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
+
+/// Subcommands and global arguments for the module
+#[derive(Parser, Debug)]
+#[command(name = "Commit-Boost Signer Service", version = VERSION, about, long_about = None)]
+struct Cli {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Parse the CLI arguments (currently only used for version info, more can be
+    // added later)
+    let _cli = Cli::parse();
+
     color_eyre::install()?;
 
     let _guard = initialize_tracing_log(SIGNER_MODULE_NAME, LogsSettings::from_env_config()?);


### PR DESCRIPTION
This adds `--version` support to the CLI, PBS, and Signer binaries. For example:

```
$ commit-boost-pbs --version
Commit-Boost PBS Service v0.9.2
```

Now people can check the version of their binaries without needing a full proper configuration to start and stop the services. This should close #375.

As a side-note, I left each config as an independent struct per binary. They're empty right now, but they use `clap` so we can easily add more stuff to them later when we fully CLI-ify each one individually.