### PR TITLE
fix(signer): introduce config to set the amount of trusted proxies in rightmost setup

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -188,10 +188,16 @@ jwt_auth_fail_timeout_seconds = 300
 # HTTP header to use to determine the real client IP, if the Signer is behind a proxy (e.g. nginx)
 # OPTIONAL. If missing, the client IP will be taken directly from the TCP connection.
 # [signer.reverse_proxy]
-# Unique: HTTP header name to use to determine the real client IP. Expected to appear only once in the request. Requests with multiple values of this header will be rejected.
-# unique = "X-Real-IP"
-# Rightmost: HTTP header name to use to determine the real client IP from a comma-separated list of IPs. Rightmost IP is the client IP. If the header appears multiple times, the last value will be used.
-# rightmost = "X-Forwarded-For"
+# Type of reverse proxy configuration. Supported values:
+# - unique: use a single HTTP header value as the client IP.
+# - rightmost: use the rightmost IP from a comma-separated list of IPs in the HTTP header.
+# type = "unique"
+# Unique: HTTP header name to use to determine the real client IP. If the header appears multiple times, the request will be rejected.
+# header = "X-Real-IP"
+# Rightmost: HTTP header name to use to determine the real client IP from a comma-separated list of IPs. If the header appears multiple times, the last value will be used.
+# header = "X-Forwarded-For"
+# Rightmost: number of trusted proxies in front of the Signer, whose IPs will be skipped when extracting the client IP from the rightmost side of the list. Must be greater than 0.
+# trusted_count = 1
 
 # [signer.tls_mode]
 # How to use TLS for the Signer's HTTP server; two modes are supported:

--- a/crates/signer/src/service.rs
+++ b/crates/signer/src/service.rs
@@ -126,7 +126,7 @@ impl SigningService {
             loaded_proxies,
             jwt_auth_fail_limit =? state.jwt_auth_fail_limit,
             jwt_auth_fail_timeout =? state.jwt_auth_fail_timeout,
-            reverse_proxy =? state.reverse_proxy,
+            reverse_proxy =% state.reverse_proxy,
             "Starting signing service"
         );
 

--- a/docs/docs/get_started/configuration.md
+++ b/docs/docs/get_started/configuration.md
@@ -401,20 +401,25 @@ jwt_auth_fail_timeout_seconds = 300 # The time window in seconds
 
 The rate limit is applied to the IP address of the client making the request. By default, the IP is extracted directly from the TCP connection. If you're running the Signer service behind a reverse proxy (e.g. Nginx), you can configure it to extract the IP from a custom HTTP header instead. There're two options:
 
-- `unique`: The name of the HTTP header that contains the IP. This header is expected to appear only once in the request. This is common when using `X-Real-IP`, `True-Client-IP`, etc. If a request is received that has multiple values for this header, it will be considered invalid and rejected.
-- `rightmost`: The name of the HTTP header that contains a comma-separated list of IPs. The rightmost IP in the list is used. If the header appears multiple times, the last occurrence is used. This is common when using `X-Forwarded-For`.
+- unique: Provides an HTTP header that contains the IP. This header is expected to appear only once in the request. This is common when using `X-Real-IP`, `True-Client-IP`, etc. If a request has multiple values for this header, it will be considered invalid and rejected.
+- `rightmost`: Provides an HTTP header that contains a comma-separated list of IPs. The nth rightmost IP in the list is used. If the header appears multiple times, the last occurrence is used. This is common when using `X-Forwarded-For`.
 
 Examples:
 
 ```toml
 [signer.reverse_proxy]
-unique = "X-Real-IP"
+type = "unique"
+header = "X-Real-IP"
 ```
 
 ```toml
 [signer.reverse_proxy]
-rightmost = "X-Forwarded-For"
+type = "rightmost"
+header = "X-Forwarded-For"
+trusted_count = 1
 ```
+
+Note: `trusted_count` is the number of trusted proxies in front of the Signer service, but the last proxy won't add its address, so the number of skipped IPs is `trusted_count - 1`. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#trusted_proxy_count) for more info.
 
 ## Custom module
 


### PR DESCRIPTION
The `rigthmost` setup for reverse proxies should allow operators to set the amount of trusted proxies so they can be skipped to detect client's IP