### PR TITLE
Allow builds from other branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: "stable"
           fetch-depth: 0
           submodules: true
 
@@ -108,7 +107,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: "stable"
           fetch-depth: 0
           submodules: true
 
@@ -168,7 +166,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: "stable"
           fetch-depth: 0
           submodules: true
 
@@ -221,7 +218,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: "stable"
           fetch-depth: 0
           submodules: true
 


### PR DESCRIPTION
This removes the explicit `stable` ref in the CI release workflow. By default, GitHub should use whatever source commit was tagged (which triggered the release) so we can avoid things like #399 in the future.

If we want to be explicit about which commit is used, we can do 
```
with:
  ref: ${{ github.sha }}
```
instead.