### PR TITLE
fix(tests): update tests for SSV API rename and PbsState signature change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ targets.json
 .idea/
 logs
 .vscode/
+
+# Nix
+.direnv/
+.devenv/
+devenv.*
+devenv.lock
+.devenv.flake.nix
+.envrc

--- a/tests/tests/pbs_cfg_file_update.rs
+++ b/tests/tests/pbs_cfg_file_update.rs
@@ -59,7 +59,8 @@ async fn test_cfg_file_update() -> Result<()> {
                                              * or anything close to it */
         extra_validation_enabled: false,
         rpc_url: None,
-        ssv_api_url: Url::parse("http://example.com").unwrap(),
+        ssv_node_api_url: Url::parse("http://example.com").unwrap(),
+        ssv_public_api_url: Url::parse("http://example.com").unwrap(),
         http_timeout_seconds: 10,
         register_validator_retry_limit: 3,
         validator_registration_batch_size: None,

--- a/tests/tests/pbs_mux.rs
+++ b/tests/tests/pbs_mux.rs
@@ -345,7 +345,7 @@ async fn test_ssv_multi_with_node() -> Result<()> {
     config.registry_muxes = Some(registry_muxes);
 
     // Run PBS service
-    let state = PbsState::new(config);
+    let state = PbsState::new(config, PathBuf::new());
     let pbs_server = tokio::spawn(PbsService::run::<(), DefaultBuilderApi>(state));
     info!("Started PBS server with pubkey {pubkey}");
 
@@ -441,7 +441,7 @@ async fn test_ssv_multi_with_public() -> Result<()> {
     config.registry_muxes = Some(registry_muxes);
 
     // Run PBS service
-    let state = PbsState::new(config);
+    let state = PbsState::new(config, PathBuf::new());
     let pbs_server = tokio::spawn(PbsService::run::<(), DefaultBuilderApi>(state));
     info!("Started PBS server with pubkey {pubkey}");
 


### PR DESCRIPTION
Align test code with recent refactors: replace removed `ssv_api_url` field with `ssv_node_api_url`/`ssv_public_api_url`, pass the new `PathBuf` argument to `PbsState::new`.