### PR TITLE
fix(signer): preserve error messages in responses

### DIFF
--- a/crates/signer/src/error.rs
+++ b/crates/signer/src/error.rs
@@ -41,11 +41,11 @@ impl IntoResponse for SignerModuleError {
             }
             SignerModuleError::UnknownProxySigner(_) => (StatusCode::NOT_FOUND, self.to_string()),
             SignerModuleError::DirkCommunicationError(_) => {
-                (StatusCode::BAD_GATEWAY, "Dirk communication error".to_string())
+                (StatusCode::BAD_GATEWAY, self.to_string())
             }
             SignerModuleError::DirkNotSupported => (StatusCode::BAD_REQUEST, self.to_string()),
             SignerModuleError::Internal(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal error".to_string())
+                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
             SignerModuleError::SignerError(err) => (StatusCode::BAD_REQUEST, err.to_string()),
             SignerModuleError::RateLimited(duration) => {


### PR DESCRIPTION
Restores detailed error messages for DirkCommunicationError and Internal by using existing thiserror formatting instead of hardcoded strings.