### PR TITLE
Cut release/v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Release Changelog
+
+### v0.9.4
+- Fix pagination issue with SSV keys
+- Bump rust toolchain to 1.91
+- Bump lighthouse dependencies to v8.1.3


### PR DESCRIPTION
### v0.9.4

- Fix pagination issue with SSV keys
- Bump rust toolchain to 1.91
- Bump lighthouse dependencies to v8.1.3