### PR TITLE
Force builds to use the same rust version

### DIFF
--- a/provisioning/build.Dockerfile
+++ b/provisioning/build.Dockerfile
@@ -73,6 +73,7 @@ COPY . .
 RUN if [ -f ${BUILD_VAR_SCRIPT} ]; then \
       chmod +x ${BUILD_VAR_SCRIPT} && \
       . ${BUILD_VAR_SCRIPT} && \
+      rustup target add ${TARGET} && \
       echo "Cross-compilation environment set up for ${TARGET}"; \
     else \
       echo "No cross-compilation needed"; \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.91"
+targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Fix build issue during releases following from upgrading to rust 1.91