### PR TITLE
Feature/commit boost default image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        crate: [pbs, signer]
+        crate: [pbs, signer, commit-boost]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v1.2.3)"
+        description: 'Release tag (e.g. v1.2.3)'
         required: true
         type: string
 
@@ -72,7 +72,7 @@ jobs:
           VALUE=$(python .github/workflows/release/release.py is-latest "${{ inputs.tag }}")
           echo "value=$VALUE" >> $GITHUB_OUTPUT
 
-  # Builds the x64 and arm64 binaries for Linux, for all 3 crates, via the Docker builder
+  # Builds the x64 and arm64 binaries for Linux via the Docker builder
   build-binaries-linux:
     needs: [resolve-tag]
     timeout-minutes: 60
@@ -250,10 +250,10 @@ jobs:
         run: |
           mkdir -p ./artifacts/bin/linux_amd64
           mkdir -p ./artifacts/bin/linux_arm64
-          tar -xzf ./artifacts/commit-boost-${{ matrix.crate }}-${{ inputs.tag }}-linux_x86-64/commit-boost-${{ matrix.crate }}-${{ inputs.tag }}-linux_x86-64.tar.gz -C ./artifacts/bin
-          mv ./artifacts/bin/commit-boost-${{ matrix.crate }} ./artifacts/bin/linux_amd64/commit-boost-${{ matrix.crate }}
-          tar -xzf ./artifacts/commit-boost-${{ matrix.crate }}-${{ inputs.tag }}-linux_arm64/commit-boost-${{ matrix.crate }}-${{ inputs.tag }}-linux_arm64.tar.gz -C ./artifacts/bin
-          mv ./artifacts/bin/commit-boost-${{ matrix.crate }} ./artifacts/bin/linux_arm64/commit-boost-${{ matrix.crate }}
+          tar -xzf ./artifacts/commit-boost-${{ inputs.tag }}-linux_x86-64/commit-boost-${{ inputs.tag }}-linux_x86-64.tar.gz -C ./artifacts/bin
+          mv ./artifacts/bin/commit-boost ./artifacts/bin/linux_amd64/commit-boost
+          tar -xzf ./artifacts/commit-boost-${{ inputs.tag }}-linux_arm64/commit-boost-${{ inputs.tag }}-linux_arm64.tar.gz -C ./artifacts/bin
+          mv ./artifacts/bin/commit-boost ./artifacts/bin/linux_arm64/commit-boost
 
       - name: Set lowercase owner
         run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
@@ -297,7 +297,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
-          pattern: "commit-boost*"
+          pattern: "commit-boost-*"
 
       - name: Sign all binaries with Sigstore
         uses: sigstore/gh-action-sigstore-python@v3.0.0
@@ -310,7 +310,7 @@ jobs:
           name: signed-${{ inputs.tag }}
           path: ./artifacts/**/*.sigstore*
 
-  # Creates a release on GitHub with the binaries
+  # Creates a draft release on GitHub with the binaries
   finalize-release:
     needs:
       - build-binaries-linux
@@ -327,13 +327,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
-          pattern: "commit-boost*"
-
-      - name: Download signatures
-        uses: actions/download-artifact@v4
-        with:
-          path: ./artifacts
-          pattern: "signatures-${{ github.ref_name }}*"
+          pattern: "commit-boost-*"
 
       - name: Download signed artifacts
         uses: actions/download-artifact@v4
@@ -350,75 +344,4 @@ jobs:
           tag_name: ${{ inputs.tag }}
           name: ${{ inputs.tag }}
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-
-  # Fast-forwards stable (full release) or beta (RC) to the new tag.
-  # Runs after all artifacts are built and the draft release is created,
-  # so stable/beta are never touched if any part of the pipeline fails.
-  fast-forward-branch:
-    needs:
-      - finalize-release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Configure git
-        run: |
-          git config user.name  "commit-boost-release-bot[bot]"
-          git config user.email "commit-boost-release-bot[bot]@users.noreply.github.com"
-
-      - name: Fast-forward beta branch (RC releases)
-        if: contains(github.ref_name, '-rc')
-        run: |
-          git checkout beta
-          git merge --ff-only "${{ github.ref_name }}"
-          git push origin beta
-
-      - name: Fast-forward stable branch (full releases)
-        if: "!contains(github.ref_name, '-rc')"
-        run: |
-          git checkout stable
-          git merge --ff-only "${{ github.ref_name }}"
-          git push origin stable
-
-  # Deletes the tag if any job in the release pipeline fails.
-  # This keeps the tag and release artifacts in sync — a tag should only
-  # exist if the full pipeline completed successfully.
-  # stable/beta are never touched on failure since fast-forward-branch
-  # only runs after finalize-release succeeds.
-  #
-  # Note: if finalize-release specifically fails, a draft release may already
-  # exist on GitHub pointing at the now-deleted tag and will need manual cleanup.
-  cleanup-on-failure:
-    needs:
-      - build-binaries-linux
-      - build-binaries-darwin
-      - sign-binaries
-      - build-and-push-pbs-docker
-      - build-and-push-signer-docker
-      - finalize-release
-      - fast-forward-branch
-    runs-on: ubuntu-latest
-    if: failure()
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Delete tag
-        run: git push origin --delete ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/tests/binary.rs
+++ b/bin/tests/binary.rs
@@ -8,13 +8,13 @@ use cb_cli::docker_init::{CB_COMPOSE_FILE, CB_ENV_FILE};
 const MINIMAL_PBS_TOML: &str = r#"
 chain = "Holesky"
 [pbs]
-docker_image = "ghcr.io/commit-boost/pbs:latest"
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 "#;
 
 const MINIMAL_WITH_MODULE_TOML: &str = r#"
 chain = "Holesky"
 [pbs]
-docker_image = "ghcr.io/commit-boost/pbs:latest"
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 
 [signer.local.loader]
 key_path = "/keys/keys.json"
@@ -127,7 +127,7 @@ fn test_init_compose_file_pbs_service_structure() {
 
     let pbs = &compose["services"]["cb_pbs"];
     assert!(!pbs.is_null(), "cb_pbs service must exist");
-    assert_eq!(pbs["image"].as_str(), Some("ghcr.io/commit-boost/pbs:latest"), "image");
+    assert_eq!(pbs["image"].as_str(), Some("ghcr.io/commit-boost/commit-boost:latest"), "image");
     assert_eq!(pbs["container_name"].as_str(), Some("cb_pbs"), "container_name");
 
     // Config file must be mounted inside the container.

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,8 +10,8 @@ chain = "Holesky"
 # Configuration for the PBS module
 [pbs]
 # Docker image to use for the PBS module.
-# OPTIONAL, DEFAULT: ghcr.io/commit-boost/pbs:latest
-docker_image = "ghcr.io/commit-boost/pbs:latest"
+# OPTIONAL, DEFAULT: ghcr.io/commit-boost/commit-boost:latest
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 # Whether to enable the PBS module to request signatures from the Signer module (not used in the default PBS image)
 # OPTIONAL, DEFAULT: false
 with_signer = false
@@ -175,8 +175,8 @@ url = "http://0xa119589bb33ef52acbb8116832bec2b58fca590fe5c85eac5d3230b44d5bc09f
 # More details on the docs (https://commit-boost.github.io/commit-boost-client/get_started/configuration/#signer-module)
 [signer]
 # Docker image to use for the Signer module.
-# OPTIONAL, DEFAULT: ghcr.io/commit-boost/signer:latest
-docker_image = "ghcr.io/commit-boost/signer:latest"
+# OPTIONAL, DEFAULT: ghcr.io/commit-boost/commit-boost:latest
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 # Host to bind the Signer API server to
 # OPTIONAL, DEFAULT: 127.0.0.1
 host = "127.0.0.1"

--- a/crates/cli/src/docker_init.rs
+++ b/crates/cli/src/docker_init.rs
@@ -24,7 +24,7 @@ use cb_common::{
     utils::random_jwt_secret,
 };
 use docker_compose_types::{
-    Compose, DependsCondition, DependsOnOptions, EnvFile, Environment, Healthcheck,
+    Command, Compose, DependsCondition, DependsOnOptions, EnvFile, Environment, Healthcheck,
     HealthcheckTest, MapOrEmpty, NetworkSettings, Networks, Ports, Service, Services, SingleValue,
     Volumes,
 };
@@ -310,6 +310,7 @@ fn create_pbs_service(service_config: &mut ServiceCreationInfo) -> eyre::Result<
     let pbs_service = Service {
         container_name: Some("cb_pbs".to_owned()),
         image: Some(cb_config.pbs.docker_image.clone()),
+        command: Some(Command::Args(vec!["pbs".to_owned()])),
         ports: Ports::Short(ports),
         volumes,
         environment: Environment::KvPair(envs),
@@ -459,6 +460,7 @@ fn create_signer_service_local(
     let signer_service = Service {
         container_name: Some("cb_signer".to_owned()),
         image: Some(signer_config.docker_image.clone()),
+        command: Some(Command::Args(vec!["signer".to_owned()])),
         networks: Networks::Simple(signer_networks),
         ports: Ports::Short(ports),
         volumes,
@@ -586,6 +588,7 @@ fn create_signer_service_dirk(
     let signer_service = Service {
         container_name: Some("cb_signer".to_owned()),
         image: Some(signer_config.docker_image.clone()),
+        command: Some(Command::Args(vec!["signer".to_owned()])),
         networks: Networks::Simple(signer_networks),
         ports: Ports::Short(ports),
         volumes,
@@ -871,7 +874,7 @@ mod tests {
             r#"
             chain = "Holesky"
             [pbs]
-            docker_image = "ghcr.io/commit-boost/pbs:latest"
+            docker_image = "ghcr.io/commit-boost/commit-boost:latest"
         "#,
         )
         .expect("valid minimal test config")
@@ -1126,7 +1129,7 @@ mod tests {
         let service = create_pbs_service(&mut sc)?;
 
         assert_eq!(service.container_name.as_deref(), Some("cb_pbs"));
-        assert_eq!(service.image.as_deref(), Some("ghcr.io/commit-boost/pbs:latest"));
+        assert_eq!(service.image.as_deref(), Some("ghcr.io/commit-boost/commit-boost:latest"));
         assert!(env_str(&service, CONFIG_ENV).is_some());
         assert!(env_str(&service, PBS_ENDPOINT_ENV).is_some());
         assert!(service.healthcheck.is_some());

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -16,7 +16,7 @@ pub const LOGS_DIR_DEFAULT: &str = "/var/logs/commit-boost";
 
 ///////////////////////// PBS /////////////////////////
 
-pub const PBS_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/pbs:latest";
+pub const PBS_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/commit-boost:latest";
 pub const PBS_SERVICE_NAME: &str = "pbs";
 
 /// Where to receive BuilderAPI calls from beacon node
@@ -26,7 +26,7 @@ pub const MUX_PATH_ENV: &str = "CB_MUX_PATH";
 
 ///////////////////////// SIGNER /////////////////////////
 
-pub const SIGNER_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/signer:latest";
+pub const SIGNER_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/commit-boost:latest";
 pub const SIGNER_SERVICE_NAME: &str = "signer";
 
 /// Where the signer module should open the server

--- a/crates/common/src/config/constants.rs
+++ b/crates/common/src/config/constants.rs
@@ -14,9 +14,11 @@ pub const METRICS_PORT_ENV: &str = "CB_METRICS_PORT";
 pub const LOGS_DIR_ENV: &str = "CB_LOGS_DIR";
 pub const LOGS_DIR_DEFAULT: &str = "/var/logs/commit-boost";
 
+/// Default Docker image
+pub const COMMIT_BOOST_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/commit-boost:latest";
+
 ///////////////////////// PBS /////////////////////////
 
-pub const PBS_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/commit-boost:latest";
 pub const PBS_SERVICE_NAME: &str = "pbs";
 
 /// Where to receive BuilderAPI calls from beacon node
@@ -26,7 +28,6 @@ pub const MUX_PATH_ENV: &str = "CB_MUX_PATH";
 
 ///////////////////////// SIGNER /////////////////////////
 
-pub const SIGNER_IMAGE_DEFAULT: &str = "ghcr.io/commit-boost/commit-boost:latest";
 pub const SIGNER_SERVICE_NAME: &str = "signer";
 
 /// Where the signer module should open the server

--- a/crates/common/src/config/pbs.rs
+++ b/crates/common/src/config/pbs.rs
@@ -23,8 +23,8 @@ use super::{
 use crate::{
     commit::client::SignerClient,
     config::{
-        CONFIG_ENV, MODULE_JWT_ENV, MuxKeysLoader, PBS_IMAGE_DEFAULT, PBS_SERVICE_NAME, PbsMuxes,
-        SIGNER_TLS_CERTIFICATE_NAME, SIGNER_TLS_CERTIFICATES_PATH_ENV, SIGNER_URL_ENV,
+        COMMIT_BOOST_IMAGE_DEFAULT, CONFIG_ENV, MODULE_JWT_ENV, MuxKeysLoader, PBS_SERVICE_NAME,
+        PbsMuxes, SIGNER_TLS_CERTIFICATE_NAME, SIGNER_TLS_CERTIFICATES_PATH_ENV, SIGNER_URL_ENV,
         SignerConfig, TlsMode, load_env_var, load_file_from_env,
     },
     pbs::{
@@ -257,7 +257,7 @@ pub struct PbsModuleConfig {
 }
 
 fn default_pbs() -> String {
-    PBS_IMAGE_DEFAULT.to_string()
+    COMMIT_BOOST_IMAGE_DEFAULT.to_string()
 }
 
 /// Loads the default pbs config, i.e. with no signer client or custom data

--- a/crates/common/src/config/signer.rs
+++ b/crates/common/src/config/signer.rs
@@ -22,7 +22,8 @@ use super::{
 };
 use crate::{
     config::{
-        DIRK_CA_CERT_ENV, DIRK_CERT_ENV, DIRK_DIR_SECRETS_ENV, DIRK_KEY_ENV, SIGNER_IMAGE_DEFAULT,
+        COMMIT_BOOST_IMAGE_DEFAULT, DIRK_CA_CERT_ENV, DIRK_CERT_ENV, DIRK_DIR_SECRETS_ENV,
+        DIRK_KEY_ENV,
     },
     signer::{ProxyStore, SignerLoader},
     types::{Chain, ModuleId},
@@ -164,7 +165,7 @@ impl SignerConfig {
 }
 
 fn default_signer_image() -> String {
-    SIGNER_IMAGE_DEFAULT.to_string()
+    COMMIT_BOOST_IMAGE_DEFAULT.to_string()
 }
 
 fn default_tls_mode() -> TlsMode {
@@ -424,7 +425,10 @@ mod tests {
     use alloy::primitives::{Uint, b256};
 
     use super::*;
-    use crate::config::{LogsSettings, ModuleKind, PbsConfig, StaticModuleConfig, StaticPbsConfig};
+    use crate::config::{
+        COMMIT_BOOST_IMAGE_DEFAULT, LogsSettings, ModuleKind, PbsConfig, StaticModuleConfig,
+        StaticPbsConfig,
+    };
 
     // Wrapper needed because TOML requires a top-level struct (can't serialize
     // a bare enum).
@@ -437,7 +441,7 @@ mod tests {
         SignerConfig {
             host: Ipv4Addr::LOCALHOST,
             port: 20000,
-            docker_image: SIGNER_IMAGE_DEFAULT.to_string(),
+            docker_image: COMMIT_BOOST_IMAGE_DEFAULT.to_string(),
             jwt_auth_fail_limit: 3,
             jwt_auth_fail_timeout_seconds: 300,
             tls_mode,
@@ -851,7 +855,7 @@ mod tests {
         cfg.signer = Some(SignerConfig {
             host: Ipv4Addr::new(127, 0, 0, 1),
             port: 20000,
-            docker_image: SIGNER_IMAGE_DEFAULT.to_string(),
+            docker_image: COMMIT_BOOST_IMAGE_DEFAULT.to_string(),
             jwt_auth_fail_limit: 3,
             jwt_auth_fail_timeout_seconds: 300,
             tls_mode: TlsMode::Insecure,

--- a/docs/docs/get_started/building.md
+++ b/docs/docs/get_started/building.md
@@ -4,7 +4,7 @@ Commit-Boost's components are all written in [Rust](https://www.rust-lang.org/).
 
 ## Building via the Docker Builder
 
-For convenience, Commit-Boost has Dockerized the build environment for Linux `x64` and `arm64` platforms. It utilizes Docker's powerful [buildx](https://docs.docker.com/reference/cli/docker/buildx/) system. All of the prerequisites, cross-compilation tooling, and configuration are handled by the builder image. If you would like to build the CLI, PBS module, or Signer binaries and Docker images from source, you are welcome to use the Docker builder process.
+For convenience, Commit-Boost has Dockerized the build environment for Linux `x64` and `arm64` platforms. It utilizes Docker's powerful [buildx](https://docs.docker.com/reference/cli/docker/buildx/) system. All of the prerequisites, cross-compilation tooling, and configuration are handled by the builder image. If you would like to build the Commit-Boost binary and Docker image from source, you are welcome to use the Docker builder process.
 
 To use the builder, you will need to have [Docker Engine](https://docs.docker.com/engine/install/) installed on your system. Please follow the instructions to install it first.
 
@@ -18,9 +18,8 @@ Use `just --list` to show all of the actions - there are many. The `justfile` pr
 
 Below is a brief summary of the relevant ones for building the Commit-Boost artifacts:
 
-- `build-all <version>` will build the `commit-boost` binary for your local system architecture. It will also create Docker images called `commit-boost/pbs:<version>` and `commit-boost/signer:<version>` and load them into your local Docker registry for use.
+- `build-all <version>` builds the `commit-boost` binary to `./build/<version>` and creates a Docker image called `commit-boost/commit-boost:<version>` (a unified image that bundles all subcommands), loading it into your local Docker registry.
 - `build-bin <version>` can be used to create the `commit-boost` binary itself.
-- `build-pbs-img <version>` and `build-signer-img <version>` can be used to create the Docker images for the PBS and Signer services, respectively.
 
 The `version` provided will be used to house the output binaries in `./build/<version>`, and act as the version tag for the Docker images when they're added to your local system or uploaded to your local Docker repository. For example, using `$(git rev-parse --short HEAD)` will set the version to the current commit hash.
 

--- a/docs/docs/get_started/running/docker.md
+++ b/docs/docs/get_started/running/docker.md
@@ -55,7 +55,7 @@ Below is a simple configuration for running only the PBS service on the Hoodi ne
 chain = "Hoodi"
 
 [pbs]
-docker_image = "ghcr.io/commit-boost/pbs:v0.8.0"
+docker_image = "ghcr.io/commit-boost/commit-boost:v0.8.0"
 relay_check = true
 wait_all_registrations = true
 
@@ -80,13 +80,15 @@ Run `commit-boost init --config cb-config.toml` with the above configuration, th
 ```
 services:
   cb_pbs:
+    command:
+    - pbs
     healthcheck:
       test: curl -f http://localhost:18550/eth/v1/builder/status
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 5s
-    image: ghcr.io/commit-boost/pbs:v0.8.0
+    image: ghcr.io/commit-boost/commit-boost:v0.8.0
     container_name: cb_pbs
     ports:
     - 127.0.0.1:18550:18550
@@ -143,7 +145,7 @@ Below is a simple configuration for running only the three modules on the Hoodi 
 chain = "Hoodi"
 
 [pbs]
-docker_image = "ghcr.io/commit-boost/pbs:v0.8.0"
+docker_image = "ghcr.io/commit-boost/commit-boost:v0.8.0"
 relay_check = true
 wait_all_registrations = true
 
@@ -204,13 +206,15 @@ services:
       cb_signer:
         condition: service_healthy
   cb_pbs:
+    command:
+    - pbs
     healthcheck:
       test: curl -f http://localhost:18550/eth/v1/builder/status
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 5s
-    image: ghcr.io/commit-boost/pbs:latest
+    image: ghcr.io/commit-boost/commit-boost:latest
     container_name: cb_pbs
     ports:
     - 127.0.0.1:18550:18550
@@ -220,13 +224,15 @@ services:
     volumes:
     - ./cb-config.toml:/cb-config.toml:ro
   cb_signer:
+    command:
+    - signer
     healthcheck:
       test: curl -f http://localhost:20000/status
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 5s
-    image: ghcr.io/commit-boost/signer:latest
+    image: ghcr.io/commit-boost/commit-boost:latest
     container_name: cb_signer
     ports:
     - 127.0.0.1:20000:20000

--- a/justfile
+++ b/justfile
@@ -38,96 +38,22 @@ build-bin-multiarch version: \
   (_docker-build-binary-multiarch version "commit-boost")
 
 [doc("""
-  Creates a Docker image named 'commit-boost/pbs:<version>' and loads it to the local Docker repository.
-  Requires the binary to be built first, but this command won't build it automatically if you just need to build the
-  Docker image without recompiling the binary.
-""")]
-build-pbs-img version: \
-  (_docker-build-image version "pbs")
-
-[doc("""
-  Builds the commit-boost binary to './build/<version>' and creates a Docker image named 'commit-boost/pbs:<version>'.
-""")]
-build-pbs version: \
-  (build-bin version) \
-  (build-pbs-img version)
-
-[doc("""
-  Creates a multiarch Docker image manifest named 'commit-boost/pbs:<version>' and pushes it to a custom Docker registry
-  (such as '192.168.1.10:5000').
-  Used for testing multiarch images locally instead of using a public registry like GHCR or Docker Hub.
-""")]
-build-pbs-img-multiarch version local-docker-registry: \
-  (_docker-build-image-multiarch version "pbs" local-docker-registry)
-
-[doc("""
-  Builds amd64 and arm64 binaries for the commit-boost crate to './build/<version>/<platform>', where '<platform>' is the
-  OS / arch platform of the binary (linux_amd64 and linux_arm64).
-  Creates a multiarch Docker image manifest named 'commit-boost/pbs:<version>' and pushes it to a custom Docker registry
-  (such as '192.168.1.10:5000').
-  Used for testing multiarch images locally instead of using a public registry like GHCR or Docker Hub.
-""")]
-build-pbs-multiarch version local-docker-registry: \
-  (build-bin-multiarch version) \
-  (build-pbs-img-multiarch version local-docker-registry)
-
-[doc("""
-  Creates a Docker image named 'commit-boost/signer:<version>' and loads it to the local Docker repository.
-  Requires the binary to be built first, but this command won't build it automatically if you just need to build the
-  Docker image without recompiling the binary.
-""")]
-build-signer-img version: \
-  (_docker-build-image version "signer")
-
-[doc("""
-  Builds the commit-boost binary to './build/<version>' and creates a Docker image named 'commit-boost/signer:<version>'.
-""")]
-build-signer version: \
-  (build-bin version) \
-  (build-signer-img version)
-
-[doc("""
-  Creates a multiarch Docker image manifest named 'commit-boost/signer:<version>' and pushes it to a custom Docker registry
-  (such as '192.168.1.10:5000').
-  Used for testing multiarch images locally instead of using a public registry like GHCR or Docker Hub.
-""")]
-build-signer-img-multiarch version local-docker-registry: \
-  (_docker-build-image-multiarch version "signer" local-docker-registry)
-
-[doc("""
-  Builds amd64 and arm64 binaries for the commit-boost crate to './build/<version>/<platform>', where '<platform>' is
-  the OS / arch platform of the binary (linux_amd64 and linux_arm64).
-  Creates a multiarch Docker image manifest named 'commit-boost/signer:<version>' and pushes it to a custom Docker registry
-  (such as '192.168.1.10:5000').
-  Used for testing multiarch images locally instead of using a public registry like GHCR or Docker Hub.
-""")]
-build-signer-multiarch version local-docker-registry: \
-  (build-bin-multiarch version) \
-  (build-signer-img-multiarch version local-docker-registry)
-
-[doc("""
-  Builds the CLI, PBS, and Signer binaries and Docker images for the specified version.
-  The binaries will be placed in './build/<version>'.
-  The Docker images will be named 'commit-boost/cli:<version>', 'commit-boost/pbs:<version>', and
-  'commit-boost/signer:<version>'.
+  Builds the commit-boost binary to './build/<version>' and creates a Docker image named 'commit-boost/commit-boost:<version>'.
 """)]
 build-all version: \
   (build-bin version) \
-  (build-pbs-img version) \
-  (build-signer-img version)
+  (_docker-build-image version "commit-boost")
 
 [doc("""
-  Builds amd64 and arm64 flavors of the CLI, PBS, and Signer binaries and Docker images for the specified version.
+  Builds amd64 and arm64 flavors of the commit-boost binary and creates a unified multiarch Docker image manifest for the specified version.
   The binaries will be placed in './build/<version>/<platform>', where '<platform>' is the
   OS / arch platform of the binary (linux_amd64 and linux_arm64).
-  Also creates multiarch Docker image manifests for each crate and pushes them to a custom Docker registry
-  (such as '192.168.1.10:5000').
+  Also pushes the image to a custom Docker registry (such as '192.168.1.10:5000').
   Used for testing multiarch images locally instead of using a public registry like GHCR or Docker Hub.
 """)]
 build-all-multiarch version local-docker-registry: \
   (build-bin-multiarch version) \
-  (build-pbs-img-multiarch version local-docker-registry) \
-  (build-signer-img-multiarch version local-docker-registry)
+  (_docker-build-image-multiarch version "commit-boost" local-docker-registry)
 
 # ===============================
 # === Builder Implementations ===

--- a/provisioning/commit-boost.Dockerfile
+++ b/provisioning/commit-boost.Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm-slim
+ARG BINARIES_PATH TARGETOS TARGETARCH
+COPY ${BINARIES_PATH}/${TARGETOS}_${TARGETARCH}/commit-boost /usr/local/bin/commit-boost
+RUN apt-get update && apt-get install -y \
+  openssl \
+  ca-certificates \
+  libssl3 \
+  libssl-dev \
+  curl && \
+  # Cleanup
+  apt-get clean autoclean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user to run the application
+RUN groupadd -g 10001 commitboost && \
+  useradd -u 10001 -g commitboost -s /sbin/nologin commitboost
+USER commitboost
+
+ENTRYPOINT ["/usr/local/bin/commit-boost"]
+CMD ["pbs"]

--- a/provisioning/k8s/commit-boost/README.md
+++ b/provisioning/k8s/commit-boost/README.md
@@ -27,7 +27,7 @@ A Helm chart for Kubernetes
 | commitBoost.pbs.config.relays | list | `[]` |  |
 | commitBoost.pbs.enable | bool | `true` |  |
 | commitBoost.pbs.image.pullPolicy | string | `"IfNotPresent"` |  |
-| commitBoost.pbs.image.repository | string | `"ghcr.io/commit-boost/pbs"` |  |
+| commitBoost.pbs.image.repository | string | `"ghcr.io/commit-boost/commit-boost"` |  |
 | commitBoost.pbs.image.tag | string | `"v0.4.0"` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/provisioning/k8s/commit-boost/values.examples.yaml
+++ b/provisioning/k8s/commit-boost/values.examples.yaml
@@ -110,7 +110,7 @@ commitBoost:
   pbs:
     enable: true
     image:
-      repository: ghcr.io/commit-boost/pbs
+      repository: ghcr.io/commit-boost/commit-boost
       pullPolicy: IfNotPresent
       tag: "v0.4.0"
     config:

--- a/provisioning/k8s/commit-boost/values.yaml
+++ b/provisioning/k8s/commit-boost/values.yaml
@@ -113,8 +113,10 @@ commitBoost:
       repository: ghcr.io/commit-boost/commit-boost
       pullPolicy: IfNotPresent
       tag: "v0.4.0"
+    command: ["commit-boost"]
+    args: ["pbs"]
     config:
-      chain: "Holesky"
+      chain: "Hoodi"
       metrics:
         server_port: 10000
         prometheus_config: "/dev/null"

--- a/provisioning/k8s/commit-boost/values.yaml
+++ b/provisioning/k8s/commit-boost/values.yaml
@@ -110,7 +110,7 @@ commitBoost:
   pbs:
     enable: true
     image:
-      repository: ghcr.io/commit-boost/pbs
+      repository: ghcr.io/commit-boost/commit-boost
       pullPolicy: IfNotPresent
       tag: "v0.4.0"
     config:

--- a/provisioning/kurtosis-config.yml
+++ b/provisioning/kurtosis-config.yml
@@ -1,23 +1,24 @@
 # ELs: geth, nethermind, erigon, besu, reth, ethrex
 # CLs: nimbus, lighthouse, lodestar, teku, prysm, and grandine
 participants:
-  - el_type: geth
-    cl_type: nimbus
-
   - el_type: nethermind
     cl_type: lighthouse
 
-  - el_type: erigon
-    cl_type: lodestar
+  # Uncomment to test different EL/CL pairs:
+  # - el_type: geth
+  #   cl_type: nimbus
 
-  - el_type: besu
-    cl_type: teku
+  # - el_type: erigon
+  #   cl_type: lodestar
 
-  - el_type: reth
-    cl_type: prysm
+  # - el_type: besu
+  #   cl_type: teku
 
-  - el_type: ethrex
-    cl_type: grandine
+  # - el_type: reth
+  #   cl_type: prysm
+
+  # - el_type: ethrex
+  #   cl_type: grandine
 
 additional_services:
   - dora
@@ -26,7 +27,7 @@ mev_type: commit-boost
 
 mev_params:
   mev_relay_image: ethpandaops/mev-boost-relay:main
-  mev_boost_image: commit-boost/pbs:kurtosis
+  mev_boost_image: commit-boost/commit-boost:kurtosis
   mev_builder_cl_image: sigp/lighthouse:latest
   mev_builder_image: ethpandaops/reth-rbuilder:develop
 
@@ -41,64 +42,3 @@ network_params:
     "giant issue aisle success illegal bike spike
     question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy
     very lucky have athlete"
-  preregistered_validator_count: 0
-  additional_mnemonics: []
-  genesis_delay: 20
-  genesis_time: 0
-  genesis_gaslimit: 60000000
-  max_per_epoch_activation_churn_limit: 8
-  churn_limit_quotient: 65536
-  ejection_balance: 16000000000
-  eth1_follow_distance: 2048
-  min_validator_withdrawability_delay: 256
-  shard_committee_period: 256
-  attestation_due_bps_gloas: 2500
-  aggregate_due_bps_gloas: 5000
-  sync_message_due_bps_gloas: 2500
-  contribution_due_bps_gloas: 5000
-  payload_attestation_due_bps: 7500
-  view_freeze_cutoff_bps: 7500
-  inclusion_list_submission_due_bps: 6667
-  proposer_inclusion_list_cutoff_bps: 9167
-  deneb_fork_epoch: 0
-  electra_fork_epoch: 0
-  fulu_fork_epoch: 0
-  gloas_fork_epoch: 18446744073709551615
-  network_sync_base_url: https://snapshots.ethpandaops.io/
-  force_snapshot_sync: false
-  data_column_sidecar_subnet_count: 128
-  samples_per_slot: 8
-  custody_requirement: 4
-  max_blobs_per_block_electra: 9
-  max_request_blocks_deneb: 128
-  max_request_blob_sidecars_electra: 1152
-  target_blobs_per_block_electra: 6
-  base_fee_update_fraction_electra: 5007716
-  additional_preloaded_contracts: {}
-  devnet_repo: ethpandaops
-  prefunded_accounts: {}
-  bpo_1_epoch: 0
-  bpo_1_max_blobs: 15
-  bpo_1_target_blobs: 10
-  bpo_1_base_fee_update_fraction: 8346193
-  bpo_2_epoch: 18446744073709551615
-  bpo_2_max_blobs: 21
-  bpo_2_target_blobs: 14
-  bpo_2_base_fee_update_fraction: 11684671
-  bpo_3_epoch: 18446744073709551615
-  bpo_3_max_blobs: 0
-  bpo_3_target_blobs: 0
-  bpo_3_base_fee_update_fraction: 0
-  bpo_4_epoch: 18446744073709551615
-  bpo_4_max_blobs: 0
-  bpo_4_target_blobs: 0
-  bpo_4_base_fee_update_fraction: 0
-  bpo_5_epoch: 18446744073709551615
-  bpo_5_max_blobs: 0
-  bpo_5_target_blobs: 0
-  bpo_5_base_fee_update_fraction: 0
-  withdrawal_type: "0x00"
-  withdrawal_address: "0x8943545177806ED17B9F23F0a21ee5948eCaa776"
-  validator_balance: 32
-  min_epochs_for_data_column_sidecars_requests: 4096
-  min_epochs_for_block_requests: 33024

--- a/tests/data/configs/pbs.happy.toml
+++ b/tests/data/configs/pbs.happy.toml
@@ -1,7 +1,7 @@
 chain = "Holesky"
 
 [pbs]
-docker_image = "ghcr.io/commit-boost/pbs:latest"
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 extra_validation_enabled = false
 host = "127.0.0.1"
 late_in_slot_time_ms = 2000

--- a/tests/data/configs/signer.happy.toml
+++ b/tests/data/configs/signer.happy.toml
@@ -1,7 +1,7 @@
 chain = "Hoodi"
 
 [pbs]
-docker_image = "ghcr.io/commit-boost/pbs:latest"
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 with_signer = true
 host = "127.0.0.1"
 port = 18550
@@ -25,7 +25,7 @@ target_first_request_ms = 200
 frequency_get_header_ms = 300
 
 [signer]
-docker_image = "ghcr.io/commit-boost/signer:latest"
+docker_image = "ghcr.io/commit-boost/commit-boost:latest"
 host = "127.0.0.1"
 port = 20000
 jwt_auth_fail_limit = 3

--- a/tests/src/utils.rs
+++ b/tests/src/utils.rs
@@ -8,8 +8,8 @@ use std::{
 use alloy::primitives::{B256, U256};
 use cb_common::{
     config::{
-        CommitBoostConfig, LogsSettings, ModuleKind, ModuleSigningConfig, PbsConfig,
-        PbsModuleConfig, RelayConfig, ReverseProxyHeaderSetup, SIGNER_IMAGE_DEFAULT,
+        COMMIT_BOOST_IMAGE_DEFAULT, CommitBoostConfig, LogsSettings, ModuleKind,
+        ModuleSigningConfig, PbsConfig, PbsModuleConfig, RelayConfig, ReverseProxyHeaderSetup,
         SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT, SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT,
         SIGNER_PORT_DEFAULT, SignerConfig, SignerType, StartSignerConfig, StaticModuleConfig,
         StaticPbsConfig, TlsMode,
@@ -131,7 +131,7 @@ pub fn get_signer_config(loader: SignerLoader, tls: bool) -> SignerConfig {
     SignerConfig {
         host: default_host(),
         port: SIGNER_PORT_DEFAULT,
-        docker_image: SIGNER_IMAGE_DEFAULT.to_string(),
+        docker_image: COMMIT_BOOST_IMAGE_DEFAULT.to_string(),
         jwt_auth_fail_limit: SIGNER_JWT_AUTH_FAIL_LIMIT_DEFAULT,
         jwt_auth_fail_timeout_seconds: SIGNER_JWT_AUTH_FAIL_TIMEOUT_SECONDS_DEFAULT,
         inner: SignerType::Local { loader, store: None },

--- a/tests/tests/config.rs
+++ b/tests/tests/config.rs
@@ -36,7 +36,7 @@ async fn test_load_pbs_happy() -> Result<()> {
     );
 
     // Docker and general settings
-    assert_eq!(config.pbs.docker_image, "ghcr.io/commit-boost/pbs:latest");
+    assert_eq!(config.pbs.docker_image, "ghcr.io/commit-boost/commit-boost:latest");
     assert!(!config.pbs.with_signer);
     assert_eq!(config.pbs.pbs_config.host, "127.0.0.1".parse::<Ipv4Addr>().unwrap());
     assert_eq!(config.pbs.pbs_config.port, 18550);


### PR DESCRIPTION
We recently updated the release process on main, but this targeted main after the last hotfix which had temporarily reverted code. Specifically it undid #425 which unified the `pbs`, `signer`, and `cli` binaries into just `commit-boost`. Since the new release process didn't include these changes, this PR captures them. 

Specifically, we're introducing a new `commit-boost` Docker image to the release process that defaults to use the `pbs` command. This is the new de facto image used throughout the project, including the Justfile. However, to remain backwards compatible, each release will continue to ship a `pbs:latest` and `signer:latest` image, which are simply clones of the `commit-boost` image but hardwired to use their `pbs` and `signer` commands respectively. 