### PR TITLE
fix(ssv): send SSV node operator ID as numeric uint64

### DIFF
--- a/crates/common/src/interop/ssv/utils.rs
+++ b/crates/common/src/interop/ssv/utils.rs
@@ -17,8 +17,13 @@ pub async fn request_ssv_pubkeys_from_ssv_node(
     http_timeout: Duration,
 ) -> eyre::Result<SSVNodeResponse> {
     let client = reqwest::ClientBuilder::new().timeout(http_timeout).build()?;
+    // The SSV node API expects operator IDs as numeric (uint64) values. Serializing the
+    // U256 directly emits a JSON string, which the node rejects with a 400, so narrow it
+    // to a u64 first.
+    let operator_id = u64::try_from(node_operator_id)
+        .map_err(|e| eyre::eyre!("SSV node operator ID does not fit in u64: {e}"))?;
     let body = json!({
-        "operators": [node_operator_id]
+        "operators": [operator_id]
     });
     let response = client.get(url).json(&body).send().await.map_err(|e| {
         if e.is_timeout() {
@@ -50,4 +55,25 @@ pub async fn request_ssv_pubkeys_from_public_api(
     let body_bytes = safe_read_http_response(response, MUXER_HTTP_MAX_LENGTH).await?;
     serde_json::from_slice::<SSVPublicResponse>(&body_bytes)
         .wrap_err("failed to parse SSV response")
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+    use serde_json::json;
+
+    #[test]
+    fn ssv_node_request_serializes_operator_as_number() {
+        let node_operator_id = U256::from(100u64);
+
+        // Regression guard: serializing the U256 directly emits a (hex) JSON string, which
+        // the SSV node rejects ("cannot unmarshal string into ... uint64").
+        let stringy = serde_json::to_string(&json!({ "operators": [node_operator_id] })).unwrap();
+        assert_eq!(stringy, r#"{"operators":["0x64"]}"#);
+
+        // The fix narrows to u64 so the operator ID is emitted as a numeric value.
+        let operator_id = u64::try_from(node_operator_id).unwrap();
+        let numeric = serde_json::to_string(&json!({ "operators": [operator_id] })).unwrap();
+        assert_eq!(numeric, r#"{"operators":[100]}"#);
+    }
 }

--- a/crates/common/src/interop/ssv/utils.rs
+++ b/crates/common/src/interop/ssv/utils.rs
@@ -17,9 +17,9 @@ pub async fn request_ssv_pubkeys_from_ssv_node(
     http_timeout: Duration,
 ) -> eyre::Result<SSVNodeResponse> {
     let client = reqwest::ClientBuilder::new().timeout(http_timeout).build()?;
-    // The SSV node API expects operator IDs as numeric (uint64) values. Serializing the
-    // U256 directly emits a JSON string, which the node rejects with a 400, so narrow it
-    // to a u64 first.
+    // The SSV node API expects operator IDs as numeric (uint64) values. Serializing
+    // the U256 directly emits a JSON string, which the node rejects with a 400,
+    // so narrow it to a u64 first.
     let operator_id = u64::try_from(node_operator_id)
         .map_err(|e| eyre::eyre!("SSV node operator ID does not fit in u64: {e}"))?;
     let body = json!({
@@ -66,8 +66,9 @@ mod tests {
     fn ssv_node_request_serializes_operator_as_number() {
         let node_operator_id = U256::from(100u64);
 
-        // Regression guard: serializing the U256 directly emits a (hex) JSON string, which
-        // the SSV node rejects ("cannot unmarshal string into ... uint64").
+        // Regression guard: serializing the U256 directly emits a (hex) JSON string,
+        // which the SSV node rejects ("cannot unmarshal string into ...
+        // uint64").
         let stringy = serde_json::to_string(&json!({ "operators": [node_operator_id] })).unwrap();
         assert_eq!(stringy, r#"{"operators":["0x64"]}"#);
 


### PR DESCRIPTION
## Problem

The SSV node `/v1/validators` API expects the `operators` field as `[]uint64`, but `request_ssv_pubkeys_from_ssv_node` serialized the operator ID directly from an alloy `U256`. serde emits `U256` as a hex string (e.g. `"0x64"`), so the request body was `{"operators":["0x64"]}`.

The SSV node rejects this with:

```
400 Bad Request: json: cannot unmarshal string into Go struct field ValidatorsRequest.operators of type uint64
```

PBS then logs a warning and silently falls back to the public `api.ssv.network` API, so registry muxes never actually use the configured local SSV node.

## Fix

Narrow the operator ID to a `u64` before building the JSON body so it serializes as a number (`{"operators":[100]}`). A bounds check guards against an out-of-range ID instead of panicking.

## Testing

- Added a regression test (`ssv_node_request_serializes_operator_as_number`) asserting the old `U256` path emits `"0x64"` and the fixed path emits `100`.
- `cargo test -p cb-common interop::ssv::utils` passes.
- Verified live against a Hoodi SSV node: `{"operators":[100]}` returns `200` with the validator list, where `{"operators":["0x64"]}` returns `400`.

Made with [Cursor](https://cursor.com)