### PR TITLE
Fix TLS provider bug when using Dirk signer

### DIFF
--- a/.releases/v0.10.0-rc3.yml
+++ b/.releases/v0.10.0-rc3.yml
@@ -1,0 +1,2 @@
+commit: "246d4646d130f82d67df07cd2f0029e1c2efe868"
+reason: "Bug fix for signer service when using Dirk."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,6 @@
 
 ### v0.10.0-rc2
 - Fix string marshaling bug when fetching keys from local SSV nodes
+
+### v0.10.0-rc3
+- Fix Crypto TLS import ordering issue that caused Dirk signer path to panic.


### PR DESCRIPTION
Users that were using the Dirk signer as part of the signer service had a panic from a missing `CryptoProvider` that was only installed when users specified TLS. This patch simply moves the install earlier so both Dirk and TLS paths work.